### PR TITLE
Fix compatibility with Parsedown 1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require": {
 		"php": ">=7.1",
-		"erusev/parsedown": "^1.7",
+		"erusev/parsedown": "~1.7.0",
 		"mustangostang/spyc": "^0.6.2"
 	}
 }

--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -155,7 +155,8 @@ class MarkdownParser extends Parsedown {
 	 */
 	protected function blockHeader( $data ) {
 		$block = parent::blockHeader( $data );
-		$id = sanitize_title_with_dashes( $block['element']['handler']['argument'] );
+		$id = sanitize_title_with_dashes( $block['element']['text'] );
+
 		return [
 			'element' => [
 				'name' => 'a',
@@ -164,7 +165,8 @@ class MarkdownParser extends Parsedown {
 					'id' => $id,
 					'class' => 'header-anchor',
 				],
-				'elements' => [ $block ],
+				'handler' => 'elements',
+				'text' => [ $block['element'] ],
 			],
 		];
 	}


### PR DESCRIPTION
Turns out we had a hidden dependency on Parsedown 1.8 betas.