### PR TITLE
Make it more obvious where to find (and/or edit) docs content

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@
 # Documentation
 
 The Documentation module provides a developer-facing interface to read the bundled documentation for Altis modules. It also provides APIs to programmatically work with documentation.
+
+Altis documentation may be accessed at [altis-dxp.com/resources/docs](https://www.altis-dxp.com/resources/docs), or within the admin dashboard of any Altis site.
+
+Documentation content combines the [guides and getting started resources](./other-docs) in this repository with the content of each individual Altis module's own `/docs` folder. To edit the content of the "Cloud" section of the documentation site, for example, you would therefore edit the files within [the `altis-cloud` repository's `/docs` folder](https://github.com/humanmade/altis-cloud/tree/master/docs).


### PR DESCRIPTION
We spent 10 minutes trying to figure out where the Cloud module documentation lives; this change may save future generations from repeating our toil.