### PR TITLE
Fix branding

### DIFF
--- a/other-docs/guides/code-review/README.md
+++ b/other-docs/guides/code-review/README.md
@@ -1,6 +1,6 @@
 # Code Review
 
-All Code Review for HM Cloud is done via GitHub in the pre set-up GitHub repository for your project. Specific development flow process varies project to project, this document only covers the required Human Made Code Review. Specifically where in the "code development to running in production" flow the Human Made Code Review needs to be performed can be discussed separately.
+All Code Review for Altis is done via GitHub in the pre set-up GitHub repository for your project. Specific development flow process varies project to project, this document only covers the required Human Made Code Review. Specifically where in the "code development to running in production" flow the Human Made Code Review needs to be performed can be discussed separately.
 
 It is required that all code review be performed on Git branches, via a GitHub Pull Request. When a given Git branch is ready for review, the following process should be followed:
 

--- a/other-docs/guides/headless/ssr.md
+++ b/other-docs/guides/headless/ssr.md
@@ -4,7 +4,7 @@ Altis provides the ability to render JavaScript-based frontends on the server.
 
 Server-side rendering allows you to provide faster load times to users, as well as a better experience for users without JavaScript or search engines.
 
-This server-side rendering is done through [v8js](https://github.com/phpv8/v8js), a JavaScript engine integrated into PHP. v8js is installed and configured on HM Cloud, as well as the local development environment provided by Altis.
+This server-side rendering is done through [v8js](https://github.com/phpv8/v8js), a JavaScript engine integrated into PHP. v8js is installed and configured on Altis, as well as the local development environment provided by Altis.
 
 Altis maintains the [react-wp-ssr library](https://github.com/humanmade/react-wp-ssr) which can be plugged into an existing React application to enable server-side rendering.
 

--- a/other-docs/guides/multiple-sites.md
+++ b/other-docs/guides/multiple-sites.md
@@ -7,7 +7,7 @@ This functionality is referred to as **multisite**, and is enabled out-of-the-bo
 
 ## Terminology
 
-With Altis, you work on a **project**. This encompasses the codebase and the hosting provided by HM Cloud.
+With Altis, you work on a **project**. This encompasses the codebase and the hosting provided by Altis.
 
 Each project can have multiple **sites**, which can represent multiple domains, subdomains, or other distinct websites. These are all powered by the same codebase and hosting.
 


### PR DESCRIPTION
This PR eliminates all appearances of the string `HM Cloud` (case-sensitive) in favour of `Altis`.

Didn’t touch any code; docs only.