### PR TITLE
Add login information for Chassis setup

### DIFF
--- a/other-docs/getting-started/README.md
+++ b/other-docs/getting-started/README.md
@@ -74,7 +74,7 @@ composer chassis init
 
 This will add Chassis to your development dependencies and prepare it to be run.
 
-The first time you run Chassis, it may take a little longer than usual, as it sets up the virtual machine. Once this is complete, you will now have a working local site at http://altis.local/
+The first time you run Chassis, it may take a little longer than usual, as it sets up the virtual machine. Once this is complete, you will now have a working local site at http://altis.local/. Visit `/wp-admin/` and login with `admin` / `password` to get started!
 
 To stop the virtual machine, run `composer chassis stop`. You can also run [Vagrant commands](https://www.vagrantup.com/docs/cli/) inside the `chassis` directory.
 


### PR DESCRIPTION
Adds login credentials to the Getting Started page. 

Fixes #81.