### PR TITLE
Remove note on 7.4 for WP 5.3

### DIFF
--- a/other-docs/guides/upgrading/v3.md
+++ b/other-docs/guides/upgrading/v3.md
@@ -55,7 +55,6 @@ The latest CMS Module brings with it WordPress version 5.3. Some of the highligh
 - For super-large images, image resizing now uses a scaled-down version of the original image, significantly improving frontend performance
 - The Block Editor has many accessibility improvements and enhanced layout features
 - Automatic image rotation
-- PHP 7.4 Support
 
 You can [find the full WordPress 5.3 release notes here](https://wordpress.org/news/2019/11/kirk/).
 

--- a/other-docs/guides/upgrading/v3.md
+++ b/other-docs/guides/upgrading/v3.md
@@ -54,7 +54,6 @@ The latest CMS Module brings with it WordPress version 5.3. Some of the highligh
 
 - For super-large images, image resizing now uses a scaled-down version of the original image, significantly improving frontend performance
 - The Block Editor has many accessibility improvements and enhanced layout features
-- Automatic image rotation
 
 You can [find the full WordPress 5.3 release notes here](https://wordpress.org/news/2019/11/kirk/).
 


### PR DESCRIPTION
We don't have PHP 7.4 in Altis, so we should not call this out. It's confusing, implying people can now use PHP 7.4