### PR TITLE
Function `get_environment_type()` must use `Altis` namespace

### DIFF
--- a/other-docs/getting-started/configuration.md
+++ b/other-docs/getting-started/configuration.md
@@ -130,7 +130,7 @@ Altis will automatically load a file located at `.config/load.php` in the root d
 require_once __DIR__ . '/revisions.php';
 
 // Load custom local config.
-if ( get_environment_type() === 'local' ) {
+if ( Altis\get_environment_type() === 'local' ) {
 	require_once __DIR__ . '/local-config.php';
 }
 ```


### PR DESCRIPTION
#### Scenario

Creating a local Altis demo setup using local-server

#### Issue
I created a custom `.config/load.php` file and refreshed the page and observered the followoing _fatal error_:

```shell
Fatal error: Uncaught Error: Call to undefined function get_environment_type() in /usr/src/app/.config/load.php:4
Stack trace:
#0 /usr/src/app/vendor/altis/core/load.php(38): require_once()
#1 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(288): Altis\{closure}('')
#2 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(312): WP_Hook->apply_filters(NULL, Array)
#3 /usr/src/app/wordpress/wp-includes/plugin.php(478): WP_Hook->do_action(Array)
#4 /usr/src/app/wp-config.php(25): do_action('altis.loaded_au...')
#5 /usr/src/app/wordpress/wp-load.php(42): require_once('/usr/src/app/wp...')
#6 /usr/src/app/wordpress/wp-admin/admin.php(34): require_once('/usr/src/app/wo...')
#7 /usr/src/app/wordpress/wp-admin/themes.php(10): require_once('/usr/src/app/wo...')
#8 {main} thrown in /usr/src/app/.config/load.php on line 4
```
Creating of `.config/load.php` is documented at https://www.altis-dxp.com/resources/docs/getting-started/configuration/#configuration-in-php

There is no reference to having to restart the server to have Altis detect the new `.config/load.php` file

I tried running `composer server stop` and `composer server start` again to see if Altis required a restart, a similar error as above was observered.

```shell

Fatal error: Uncaught Error: Call to undefined function get_environment_type() in /usr/src/app/.config/load.php:4
Stack trace:
#0 /usr/src/app/vendor/altis/core/load.php(38): require_once()
#1 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(288): WP_CLI\Runner->Altis\{closure}('')
#2 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(312): WP_Hook->apply_filters(NULL, Array)
#3 /usr/src/app/wordpress/wp-includes/plugin.php(478): WP_Hook->do_action(Array)
#4 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1150) : eval()'d code(24): do_action('altis.loaded_au...')
#5 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1150): eval()
#6 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1111): WP_CLI\Runner->load_wordpress()
#7 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(23): WP_CLI\Runner->start()
#8 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(74): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#9 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(23): WP_CLI\bootstrap()
#10 phar:///usr/local/bin/wp/php/boot-phar.php(11): include('phar:///usr/loc...')
#11 /usr/local/bin/wp(4): include('phar:///usr/loc...')
#12 {main}
  thrown in /usr/src/app/.config/load.php on line 4

Fatal error: Uncaught Error: Call to undefined function get_environment_type() in /usr/src/app/.config/load.php:4
Stack trace:
#0 /usr/src/app/vendor/altis/core/load.php(38): require_once()
#1 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(288): WP_CLI\Runner->Altis\{closure}('')
#2 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(312): WP_Hook->apply_filters(NULL, Array)
#3 /usr/src/app/wordpress/wp-includes/plugin.php(478): WP_Hook->do_action(Array)
#4 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1150) : eval()'d code(24): do_action('altis.loaded_au...')
#5 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1150): eval()
#6 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1111): WP_CLI\Runner->load_wordpress()
#7 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(23): WP_CLI\Runner->start()
#8 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(74): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#9 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(23): WP_CLI\bootstrap()
#10 phar:///usr/local/bin/wp/php/boot-phar.php(11): include('phar:///usr/loc...')
#11 /usr/local/bin/wp(4): include('phar:///usr/loc...')
#12 {main}
  thrown in /usr/src/app/.config/load.php on line 4
WordPress install failed.
```

My `.config.load.php` file:

```php
<?php

// Load custom local config for Query Monitor.
if ( get_environment_type() === 'local' ) {

	// Enable dark mode for Query Monitor's interface.
	// Default value: false
	define( 'QM_DARK_MODE', true );

	// Enable the Capability Checks panel.
	// Default value: false
	define( 'QM_ENABLE_CAPS_PANEL', true );

	// In the Hooks & Actions panel, show every hook that has an action or
	// filter attached (instead of every action hook that fired during the request).
	// Default value: false
	define( 'QM_SHOW_ALL_HOOKS', true );
}
```

#### Solution

- The `get_environment_type()` function must be _namespaced_, i.e. `Altis\get_environment_type()` must be used in `.config/load.php`

- This is documented in https://github.com/humanmade/altis-core/blob/master/docs/README.md#core:
> Note: all functions documented below are under the `Altis` namespace.