### PR TITLE
Add further V3 deployment instructions

### DIFF
--- a/other-docs/guides/upgrading/v3.md
+++ b/other-docs/guides/upgrading/v3.md
@@ -22,7 +22,7 @@ Next remove the `vendor` directory by running `rm -rf vendor` or on Windows `rmd
 
 Next run `composer update` to complete the upgrade. You should commit the updated `composer.json` and `composer.lock` files.
 
-When deploying to Altis environments, you will need to clear the build cache using the "Clear build cache" button. This button is located under the "Advanced actions" toggle on the Release tab of your dashboard. 
+Before deploying to Altis environments, you will need to clear the build cache using the "Clear build cache" button. This button is located under the "Advanced actions" toggle on the Release tab of your dashboard. 
 
 Lastly you will need to update your database tables using the CLI:
 

--- a/other-docs/guides/upgrading/v3.md
+++ b/other-docs/guides/upgrading/v3.md
@@ -22,6 +22,8 @@ Next remove the `vendor` directory by running `rm -rf vendor` or on Windows `rmd
 
 Next run `composer update` to complete the upgrade. You should commit the updated `composer.json` and `composer.lock` files.
 
+When deploying to Altis environments, you will need to clear the build cache using the "Clear build cache" button. This button is located under the "Advanced actions" toggle on the Release tab of your dashboard. 
+
 Lastly you will need to update your database tables using the CLI:
 
 - On [Altis Dashboard](https://dashboard.altis-dxp.com/) find the stack you have deployed to and run `core update-db --network` (`wp` is automatically prepended) in the WP CLI tab

--- a/other-docs/guides/upgrading/v3.md
+++ b/other-docs/guides/upgrading/v3.md
@@ -24,7 +24,7 @@ Next run `composer update` to complete the upgrade. You should commit the update
 
 Lastly you will need to update your database tables using the CLI:
 
-- On [Altis Dashboard](https://dashboard.altis-dxp.com/) find the stack you have deployed to and run `wp core update-db --network` in the WP CLI tab
+- On [Altis Dashboard](https://dashboard.altis-dxp.com/) find the stack you have deployed to and run `core update-db --network` (`wp` is automatically prepended) in the WP CLI tab
 - For Local Chassis run `composer chassis exec -- wp core update-db --network`
 - For Local Server run `composer local-server cli -- core update-db --network`
 


### PR DESCRIPTION
The v3 upgrade guide is missing an important note about needing to clear the build cache when deploying. If you don't it fails when trying to copy a non-existent file. The error is related to this PR: https://github.com/humanmade/altis-cms-installer/pull/28/files