### PR TITLE
Add the ability to skip internal links

### DIFF
--- a/inc/class-markdownparser.php
+++ b/inc/class-markdownparser.php
@@ -99,6 +99,14 @@ class MarkdownParser extends Parsedown {
 		$parts = wp_parse_url( $href );
 		if ( ! empty( $parts['scheme'] ) ) {
 			$new_url = convert_internal_link( $href );
+
+			// Allow shortcircuiting (e.g. for public display)
+			if ( $new_url === null ) {
+				$result['element']['name'] = 'span';
+				$result['element']['attributes'] = [];
+				return $result;
+			}
+
 			if ( $new_url !== $href ) {
 				$result['element']['attributes']['href'] = $new_url;
 			}


### PR DESCRIPTION
This allows us to filter out `internal://` links from public display for places like the docs site.