### PR TITLE
Add internal docs link type for support tickets

### DIFF
--- a/docs/linking.md
+++ b/docs/linking.md
@@ -62,3 +62,14 @@ For example, to link to the current user's profile page:
 ```md
 [View your profile](internal://admin/profile.php)
 ```
+
+
+## Link to support
+
+You can easily display a direct link to the Altis support ticket system, pre-filled with the current environment stack name.
+
+These links use the special `support://` URL scheme, followed by the keyword `new`:
+
+```md
+[Open a support ticket](support://new)
+```

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -359,7 +359,7 @@ function convert_internal_link( $url ) {
 			}
 
 			$stack_name = Altis\get_environment_name();
-			$new_url .= '?applications[]=' . $stack_name;
+			$new_url .= '?applications[]=' . urlencode( $stack_name );
 			break;
 
 		default:

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -349,6 +349,19 @@ function convert_internal_link( $url ) {
 			}
 			break;
 
+		case 'support':
+			$map = [
+				'new' => 'https://dashboard.altis-dxp.com/#/support/new',
+			];
+			$new_url = $map[ $host ] ?? null;
+			if ( empty( $new_url ) ) {
+				return $url;
+			}
+
+			$stack_name = Altis\get_environment_name();
+			$new_url .= '?applications[]=' . $stack_name;
+			break;
+
 		default:
 			return $url;
 	}


### PR DESCRIPTION
Adds an internal link type for linking directly to the support ticket system, with the current environment name filled in.

See #116 