### PR TITLE
add note about db character set

### DIFF
--- a/other-docs/guides/migrating-from-wordpress.md
+++ b/other-docs/guides/migrating-from-wordpress.md
@@ -2,6 +2,10 @@
 
 This guide covers how to migrate a typical WordPress project to Altis.
 
+## Before You Begin -- Database Configuration
+
+Altis uses the `utf8mb4` MySQL database character set. It's important to check the charset configuration of the site you're migrating from and update it before importing the database into Altis to prevent data corruption.
+
 ## Setup Composer
 
 If the project does not already have a `composer.json` in the root of the repository, you should run `composer init` from the project root. This will prompt you fill out the required fields. For now, don’t bother adding any dependencies. If you already have a `composer.json` move to Remove Dependencies.


### PR DESCRIPTION
I'm not sure it's explained entirely accurately, or completely, but pushing it up for review for now, so it can be improved/updated. 

Specifically, I'd like to know what suggestions there are if a database _is_ in the wrong character set -- I'm assuming the idea is that that should be updated prior to importing into the (hosted) Altis platform, and that that change could be made locally (or on the server). Are there specific DB commands that should be run? Is it better to run these locally (I assume so)? What happens and what are the risks if (like in https://github.com/humanmade/standard-chartered/issues/10147) it's less about the origin database being in something completely incompatible (like `latin1`) and, instead a mix of character sets?