### PR TITLE
Note that the AMP-WP plugin has to be required from wpackagist

### DIFF
--- a/other-docs/guides/upgrading/v5.md
+++ b/other-docs/guides/upgrading/v5.md
@@ -41,10 +41,10 @@ If you use Local Chassis you will need to also update Chassis and its extensions
 
 The AMP and Facebook Instant Articles plugins have been unbundled from Altis. This allows you to specify the versions of each directly in your Composer requirements. While these are no longer included with Altis, we plan to maintain compatibility with AMP in new features as necessary.
 
-If you're using AMP in your project, after updating your Altis requirements, you will need to additionally require the AMP plugin:
+If you're using AMP in your project, after updating your Altis requirements, you will need to additionally require the AMP plugin. This requires first [adding WordPress Packagist as a repository](docs://getting-started/third-party-plugins#managing-plugins-via-composer), then requiring the plugin from wpackagist:
 
 ```sh
-$ composer require ampproject/amp-wp@1
+$ composer require wpackagist-plugin/amp@1
 ```
 
 Note that while Altis v4 bundles version 1 of the AMP plugin, version 2 is now available with [many major changes](https://github.com/ampproject/amp-wp/releases/tag/2.0.0), so consider updating at the same time.


### PR DESCRIPTION
The upgrade instructions here previously called for requiring the AMP plugin from the packagist repository. The AMP Project hasn't published the plugin there, so in order to manage it with composer it's necessary to either require it from github as a vcs dependency or from the wpackagist-plugin repo. 

This updates the instructions to require it from wpackagist, for consistency with the FBIA instructions.