### PR TITLE
Add note on config.platform.php property

### DIFF
--- a/other-docs/guides/upgrading/v6.md
+++ b/other-docs/guides/upgrading/v6.md
@@ -2,7 +2,9 @@
 
 _If you are migrating from WordPress to Altis, check out the [migrating guide here](../migrating-from-wordpress.md) first._
 
-To upgrade to Altis v6, edit your `composer.json` and change the version constraint for `altis/altis` and any local environment modules to `^6.0.0`:
+To upgrade to Altis v6, edit your `composer.json` and change the version constraint for `altis/altis` and any local environment modules to `^6.0.0`.
+
+In addition you will need to change the `config.platform.php` property to `7.2.34` (if present).
 
 ```json
 {
@@ -12,11 +14,18 @@ To upgrade to Altis v6, edit your `composer.json` and change the version constra
 	"require-dev": {
 		"altis/local-chassis": "^6.0.0",
 		"altis/local-server": "^6.0.0"
+	},
+	"config": {
+		"platform": {
+			"php": "7.2.34"
+		}
 	}
 }
 ```
 
 Next run `composer update` to complete the upgrade. You should commit the updated `composer.json` and `composer.lock` files.
+
+### Database Updates
 
 You will need to update your database tables using the CLI:
 


### PR DESCRIPTION
It is necessary to set the `config.platform.php` property in `composer.json` to something higher than or equal to `7.2.5` for the composer install to work properly.