### PR TITLE
Revert 75df72a to restore vendor deletion step in v6 upgrade

### DIFF
--- a/other-docs/guides/upgrading/v6.md
+++ b/other-docs/guides/upgrading/v6.md
@@ -23,6 +23,10 @@ In addition you will need to change the `config.platform.php` property to `7.2.3
 }
 ```
 
+Next, remove the `vendor` directory by running `rm -rf vendor` or on Windows `rmdir vendor`. You could also delete the directory using your code editor, Finder or Explorer.
+
+**Note:** due to an issue in how Composer handles installation of `composer-plugin` packages the above step is required to ensure the new version of the required packages are used to manage the process.
+
 Next run `composer update` to complete the upgrade. You should commit the updated `composer.json` and `composer.lock` files.
 
 ### Database Updates


### PR DESCRIPTION
Reverts 75df72aed1ad2bb6af3232e1e18b61703225dc88 — I ran into a missing file issue while migrating a local Altis Skeleton site from v5 to v6, and vendor/ deletion solved the issue. Per @rmccue, while we may have fixed this in the long term it's possible we need to include this manual step in the upgrade one more time.