### PR TITLE
Adding require-login to the composer dependencies to remove in the migration guide.

### DIFF
--- a/other-docs/guides/migrating-from-wordpress.md
+++ b/other-docs/guides/migrating-from-wordpress.md
@@ -30,6 +30,7 @@ Do the same for `hm-platform` if you have this project dependency. Altis also in
 - `meta-tags`
 - `msm-sitemap`
 - `query-monitor`
+- `require-login`
 - `smart-media`
 - `stream`
 - `two-factor`


### PR DESCRIPTION
While starting an Altis migration, I received an error when trying to install `altis/altis` because `humanmade/require-login` was still a composer dependency and it is required by `altis/security`.