### PR TITLE
Sort pages alphabetically if no order is set

### DIFF
--- a/inc/class-group.php
+++ b/inc/class-group.php
@@ -67,6 +67,10 @@ class Group {
 			$order_a = $a->get_meta( 'order' ) ?? 0;
 			$order_b = $b->get_meta( 'order' ) ?? 0;
 
+			if ( $order_a === $order_b ) {
+				return strnatcasecmp( $a->get_meta( 'title' ), $b->get_meta( 'title' ) );
+			}
+
 			return $order_a <=> $order_b;
 		} );
 


### PR DESCRIPTION
By default, these are sorted by inode, which is kind of useless. This updates to match the public docs site.