### PR TITLE
Update "Global Media Library" URL

### DIFF
--- a/other-docs/guides/upgrading/v8.md
+++ b/other-docs/guides/upgrading/v8.md
@@ -65,7 +65,7 @@ If you had code integrating with the legacy post cloner feature through any acti
 
 Altis includes a Global Content Repository framework. This is a site on the network that can be used to distribute content elsewhere via the REST API or directly to other sites on the network. The Global Content Repository framework powers the new Global Media Library. When the Global Media Library component is enabled in your Altis config, it enables any site on the network to access a common library of images without needing to re-upload anything. Whenever an image from the Global Media Library is used in a post, all the links point back to the original URL in the Global Repository, while allowing the local site's metadata (captions, alt text, etc) to be changed and stored locally.
 
-You can read more in the documentation about the [Global Content Repository](docs://core/global-content-repository.md), [Global Media Library](docs:///media/global-media-library.md) and the [Asset Manager Framework](docs://media/asset-manager-framework.md) that makes this feature possible.
+You can read more in the documentation about the [Global Content Repository](docs://core/global-content-repository.md), [Global Media Library](docs://media/global-media-library.md) and the [Asset Manager Framework](docs://media/asset-manager-framework.md) that makes this feature possible.
 
 Additionally the Asset Manager Framework makes it possible to build integrations with any Digital Asset Manager (DAM) out there, meaning editors could easily search and pull images from multiple sources through the same interface.
 


### PR DESCRIPTION
Previously three `///` slashes were in the `docs:` URL, updated to only use two `//` slashs