### PR TITLE
Fix PHPCS command

### DIFF
--- a/other-docs/guides/code-review/README.md
+++ b/other-docs/guides/code-review/README.md
@@ -98,4 +98,4 @@ echo $test;
 
 To do so ensure you have the [humanmade/coding-standards](https://github.com/humanmade/coding-standards) cloned into your repo using composer `composer require --dev humanmade/coding-standards`.
 
-An Altis command is still in development, however, since the ACR is based on a custom PHPCS standard the process can be executed locally by running the following command `vendor/bin/phpcs -e --standard=HM-Minimum`.
+An Altis command is still in development, however, since the ACR is based on a custom PHPCS standard the process can be executed locally by running the following command `vendor/bin/phpcs -p --standard=HM-Minimum .`.


### PR DESCRIPTION
The documentation currently states running `vendor/bin/phpcs -e --standard=HM-Minimum` will run the equivalent of ACR locally. However, the `-e` flag _explains_ the sniffs and does not run them. This updates the command to run in the current directory, and shows a progress bar so the user can see feedback that the command is being run.