### PR TITLE
Use `--dev` flag for `composer require`

### DIFF
--- a/other-docs/guides/updating-elasticsearch/README.md
+++ b/other-docs/guides/updating-elasticsearch/README.md
@@ -39,8 +39,8 @@ It is recommended to update your local environment's Elasticsearch version befor
    - Local Chassis: `composer chassis destroy`
 1. Require Local Server or Local Chassis version 8.1 or higher:
    ```sh
-   composer require altis/local-server:^8.1.0-rc
-   composer require altis/local-chassis:^8.1.0-rc
+   composer require --dev altis/local-server:^8.1.0-rc
+   composer require --dev altis/local-chassis:^8.1.0-rc
    ```
 1. Upgrade if using Local Chassis by running `composer chassis upgrade`
 1. Start your environment and re-import your data:

--- a/other-docs/guides/updating-elasticsearch/README.md
+++ b/other-docs/guides/updating-elasticsearch/README.md
@@ -39,8 +39,8 @@ It is recommended to update your local environment's Elasticsearch version befor
    - Local Chassis: `composer chassis destroy`
 1. Require Local Server or Local Chassis version 8.1 or higher:
    ```sh
-   composer require --dev altis/local-server:^8.1.0-rc
-   composer require --dev altis/local-chassis:^8.1.0-rc
+   composer require --dev --update-with-dependencies altis/local-server:^8.1.0@RC
+   composer require --dev --update-with-dependencies altis/local-chassis:^8.1.0@RC
    ```
 1. Upgrade if using Local Chassis by running `composer chassis upgrade`
 1. Start your environment and re-import your data:


### PR DESCRIPTION
As _local-server_ and _local-chassis_ are installed as _dev_ dependencies I've added the `--dev` flag to the install instructions here, that said, these instructions vary slightly to those documented at:

> https://docs.altis-dxp.com/nightly/guides/module-preview-releases/#opting-in

> 
> ```
> composer require altis/<module> <version>@RC --update-with-dependencies
> ```
>
> This will override the version constraint in the `altis/altis` meta package for the target module only. The `@RC` modifier allows you to use a different minimum stability setting for the target package only. All other packages will be resolved using the default minimum stability setting.

As such I'm unsure if both docs should or should not have the `@RC` or the `--update-with-dependencies`
