### PR TITLE
Include `-rc` in the `local-server` version

### DIFF
--- a/other-docs/guides/updating-elasticsearch/README.md
+++ b/other-docs/guides/updating-elasticsearch/README.md
@@ -39,8 +39,8 @@ It is recommended to update your local environment's Elasticsearch version befor
    - Local Chassis: `composer chassis destroy`
 1. Require Local Server or Local Chassis version 8.1 or higher:
    ```sh
-   composer require --dev --update-with-dependencies altis/local-server:^8.1.0@RC
-   composer require --dev --update-with-dependencies altis/local-chassis:^8.1.0@RC
+   composer require --dev --update-with-dependencies altis/local-server:^8.1.0-rc@RC
+   composer require --dev --update-with-dependencies altis/local-chassis:^8.1.0-rc@RC
    ```
 1. Upgrade if using Local Chassis by running `composer chassis upgrade`
 1. Start your environment and re-import your data:


### PR DESCRIPTION
Follow up to #280, the version on packagist is `8.1.0-rc`, hence it needs to be `8.1.0-rc@RC`, I think