### PR TITLE
Fix dependabot config to allow indirect dependency updates

### DIFF
--- a/other-docs/guides/automatic-updates.md
+++ b/other-docs/guides/automatic-updates.md
@@ -27,6 +27,14 @@ updates:
     dependency-type: all
   # Increase limit to number of Altis modules
   open-pull-requests-limit: 15
+# Optional: Generic update configuration for top level project dependencies
+- package-ecosystem: composer
+  directory: /
+  schedule:
+    interval: daily
+  versioning-strategy: lockfile-only
+  ignore:
+  - dependency-name: altis/*
 ```
 
 Finally commit this file to your repo, and you're done.


### PR DESCRIPTION
The currently documented dependabot config was not resulting in automated PRs for dependencies of the altis/altis meta package.

Fixes #287