### PR TITLE
Require Checkout action step in auto merge docs

### DIFF
--- a/other-docs/guides/automatic-updates.md
+++ b/other-docs/guides/automatic-updates.md
@@ -55,6 +55,7 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
           github-token: ${{ secrets.mytoken }}


### PR DESCRIPTION
The documented dependabot auto merge action requires that the checkout step comes first for the config file to be available, I missed that previously.