### PR TITLE
Fix invalid yaml in dependabot example code

### DIFF
--- a/other-docs/guides/automatic-updates.md
+++ b/other-docs/guides/automatic-updates.md
@@ -24,7 +24,7 @@ updates:
   # Ensure all Altis modules recieve update PRs
   allow:
   - dependency-name: altis/*
-    dependency-type: all
+  - dependency-type: all
   # Increase limit to number of Altis modules
   open-pull-requests-limit: 15
 # Optional: Generic update configuration for top level project dependencies

--- a/other-docs/guides/automatic-updates.md
+++ b/other-docs/guides/automatic-updates.md
@@ -27,14 +27,6 @@ updates:
   - dependency-type: all
   # Increase limit to number of Altis modules
   open-pull-requests-limit: 15
-# Optional: Generic update configuration for top level project dependencies
-- package-ecosystem: composer
-  directory: /
-  schedule:
-    interval: daily
-  versioning-strategy: lockfile-only
-  ignore:
-  - dependency-name: altis/*
 ```
 
 Finally commit this file to your repo, and you're done.


### PR DESCRIPTION
I copy pasted the provided dependabot config file into my project id didn't work for a couple of reasons. 

Firstly - the yaml is not valid, which is a quick fix. 

Secondly, I get the following error: 

`The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'`

Seems that it isn't possible to configure things in the way you are trying to do it here. I propose just removing it from the example.