### PR TITLE
Ensure subpages are ordered just like regular pages

### DIFF
--- a/inc/class-page.php
+++ b/inc/class-page.php
@@ -112,7 +112,19 @@ class Page {
 	 * @return Page[]
 	 */
 	public function get_subpages() : array {
-		return $this->subpages;
+		$pages = $this->subpages;
+		uasort( $pages, function ( Page $a, Page $b ) {
+			$order_a = $a->get_meta( 'order' ) ?? 0;
+			$order_b = $b->get_meta( 'order' ) ?? 0;
+
+			if ( $order_a === $order_b ) {
+				return strnatcasecmp( $a->get_meta( 'title' ), $b->get_meta( 'title' ) );
+			}
+
+			return $order_a <=> $order_b;
+		} );
+
+		return $pages;
 	}
 
 	/**

--- a/other-docs/guides/upgrading/v10.md
+++ b/other-docs/guides/upgrading/v10.md
@@ -1,3 +1,6 @@
+---
+order: 10
+---
 # Upgrading to v10
 
 _If you are migrating from WordPress to Altis, check out the [migrating guide here](../migrating-from-wordpress.md) first._

--- a/other-docs/guides/upgrading/v2.md
+++ b/other-docs/guides/upgrading/v2.md
@@ -1,3 +1,6 @@
+---
+order: 2
+---
 # Upgrading to v2
 
 _If you are migrating an existing install to Altis check out the [migrating guide here](../migrating-from-wordpress.md) first._

--- a/other-docs/guides/upgrading/v3.md
+++ b/other-docs/guides/upgrading/v3.md
@@ -1,3 +1,6 @@
+---
+order: 3
+---
 # Upgrading to v3
 
 _If you are migrating an existing install to Altis check out the [migrating guide here](../migrating-from-wordpress.md) first._

--- a/other-docs/guides/upgrading/v4.md
+++ b/other-docs/guides/upgrading/v4.md
@@ -1,3 +1,6 @@
+---
+order: 4
+---
 # Upgrading to v4
 
 _If you are migrating from WordPress to Altis, check out the [migrating guide here](../migrating-from-wordpress.md) first._

--- a/other-docs/guides/upgrading/v5.md
+++ b/other-docs/guides/upgrading/v5.md
@@ -1,3 +1,6 @@
+---
+order: 5
+---
 # Upgrading to v5
 
 _If you are migrating from WordPress to Altis, check out the [migrating guide here](../migrating-from-wordpress.md) first._

--- a/other-docs/guides/upgrading/v6.md
+++ b/other-docs/guides/upgrading/v6.md
@@ -1,3 +1,6 @@
+---
+order: 6
+---
 # Upgrading to v6
 
 _If you are migrating from WordPress to Altis, check out the [migrating guide here](../migrating-from-wordpress.md) first._

--- a/other-docs/guides/upgrading/v7.md
+++ b/other-docs/guides/upgrading/v7.md
@@ -1,3 +1,6 @@
+---
+order: 7
+---
 # Upgrading to v7
 
 _If you are migrating from WordPress to Altis, check out the [migrating guide here](../migrating-from-wordpress.md) first._

--- a/other-docs/guides/upgrading/v8.md
+++ b/other-docs/guides/upgrading/v8.md
@@ -1,3 +1,6 @@
+---
+order: 8
+---
 # Upgrading to v8
 
 _If you are migrating from WordPress to Altis, check out the [migrating guide here](../migrating-from-wordpress.md) first._

--- a/other-docs/guides/upgrading/v9.md
+++ b/other-docs/guides/upgrading/v9.md
@@ -1,3 +1,6 @@
+---
+order: 9
+---
 # Upgrading to v9
 
 _If you are migrating from WordPress to Altis, check out the [migrating guide here](../migrating-from-wordpress.md) first._


### PR DESCRIPTION
Subpages couldn't have an `order` specified, which was a problem for the (incoming) migration changes I was making.

While I was in here, I fixed #339