### PR TITLE
Update V10 upgrade guide incomplete bullet point

### DIFF
--- a/other-docs/guides/upgrading/v10.md
+++ b/other-docs/guides/upgrading/v10.md
@@ -88,6 +88,6 @@ The latest version of ElasticPress introduces lots of bug fixes and enhancements
 - The ability to index comments, this is disabled by default but can be enabled via your config
 - New CLI commands to help with debugging:
   - `wp elasticpress get-mapping` shows the current mapping configuration for the specified indexes
-  - `wp elasticpress request` request allows you to execute arbitrary requests from the command line to aid with debugging or maybe just wp elasticpress request allows you to execute arbitrary requests from the command line
+  - `wp elasticpress request` allows you to execute arbitrary requests from the command line to aid with debugging
 - Improved `WP_Query` argument support for options like `post_name__in`, `category__not_in` and more
 - Client side autosuggest improvements including support for filtering by post type and modifying dropdown display output

--- a/other-docs/guides/upgrading/v10.md
+++ b/other-docs/guides/upgrading/v10.md
@@ -88,6 +88,6 @@ The latest version of ElasticPress introduces lots of bug fixes and enhancements
 - The ability to index comments, this is disabled by default but can be enabled via your config
 - New CLI commands to help with debugging:
   - `wp elasticpress get-mapping` shows the current mapping configuration for the specified indexes
-  - `wp elasticpress request` allows you to execute arbitrary requests from the command line to aid with
+  - `wp elasticpress request` request allows you to execute arbitrary requests from the command line to aid with debugging or maybe just wp elasticpress request allows you to execute arbitrary requests from the command line
 - Improved `WP_Query` argument support for options like `post_name__in`, `category__not_in` and more
 - Client side autosuggest improvements including support for filtering by post type and modifying dropdown display output


### PR DESCRIPTION
Looks like the end of the following point has been cut off somewhere along the line.
`wp elasticpress request allows you to execute arbitrary requests from the command line to aid with`

See: https://docs.altis-dxp.com/guides/upgrading/v10/#elasticpress-36-1

Suggested change from the original issue:
>`wp elasticpress request` allows you to execute arbitrary requests from the command line to aid with debugging or maybe just wp elasticpress request allows you to execute arbitrary requests from the command line

Original issue #335 