### PR TITLE
Make it explicit that v11 is using 8.0 experimental

### DIFF
--- a/other-docs/guides/updating-php/README.md
+++ b/other-docs/guides/updating-php/README.md
@@ -11,15 +11,16 @@ There are 2 key steps to getting ready for a new version of PHP:
 
 **Note:** PHP 8.0 will officially be available from the Altis v12 release date onwards. Altis v11 will run on PHP 8.0 but support is experimental. Keep reading to learn how to prepare your application for a new PHP version.
 
-|Altis|PHP Version|
-|-|-|
-|v13|8.0|
-|v12|7.4, 8.0|
-|v11|7.4, 8.0 (experimental)|
-|v7-v11|7.4|
-|v5-v6|7.2-7.4|
-|v4|7.0-7.4|
-|v1-v3|7.0-7.2|
+| Altis  | PHP 7.4        | PHP 8.0        |
+| ------ | -------------- | -------------- |
+| v13    |                | **Supported**  |
+| v12    | *Deprecated*   | **Supported**  |
+| v11    | **Supported**  | *Experimental* |
+| v10    | **Supported**  |                |
+| v9     | **Supported**  |                |
+| v8     | **Supported**  |                |
+| v7     | **Supported**  |                |
+
 
 ## Checking PHP Version Compatibiliity
 

--- a/other-docs/guides/updating-php/README.md
+++ b/other-docs/guides/updating-php/README.md
@@ -14,8 +14,8 @@ There are 2 key steps to getting ready for a new version of PHP:
 |Altis|PHP Version|
 |-|-|
 |v13|8.0|
-|v12|7.4-8.0|
-|v11|7.4-8.0 (experimental)|
+|v12|7.4, 8.0|
+|v11|7.4, 8.0 (experimental)|
 |v7-v11|7.4|
 |v5-v6|7.2-7.4|
 |v4|7.0-7.4|


### PR DESCRIPTION
and make it obvious that PHP 7.4 is not experimental by switching the use of a hyphen to a comma. 

Also done it for v12 to keep with consistency as it is not a range of versions, but a list of versions.

Polishes up https://github.com/humanmade/product-dev/issues/1019