### PR TITLE
Add missing breaking changes to v10 upgrade guide

### DIFF
--- a/other-docs/guides/upgrading/v10.md
+++ b/other-docs/guides/upgrading/v10.md
@@ -47,6 +47,24 @@ ElasticPress has been updated to version 3.6 and will require a full reindex aft
 
 The new Insights Dashbaord completely replaces the standard WordPress admin dashboard that users see after logging in. If you need to keep the old dashboard because you have custom dashboard widgets, or you simply prefer it, then [the Insights Dashboard can be switched off via the Altis config as shown in this guide](docs://analytics/native/README.md#dashboards).
 
+### Custom Modules
+
+[The way Altis modules are registered has changed](docs://core/custom-modules.md) to allow for future improvements such as schemas for validating config. The `$default_settings` parameter is now a more generic `$options` array with the defaults as a nested array under the key `defaults`, for example:
+
+```php
+Altis\register_module( 'custom-module', __DIR__, 'Custom Module', [
+  'defaults' => [ // Previous value for the 3rd parameter is now nested under the 'defaults' key.
+    'enabled' => true,
+  ],
+], function () {
+  // bootstrap module...
+} );
+```
+
+### Composer Version
+
+You may encounter the error "`Altis\get_config()` is not defined" when running `composer update` for the first time. Please ensure your Composer version is up to date by running `composer self-update` and try again if this happens.
+
 ## Headline Features
 
 ### Insights and Analytics Dashboards


### PR DESCRIPTION
We missed the change to Custom Module registration and also a note about errors that can occur if Composer itself is out of date.

Props @goldenapples for the nudge and sorry it took so long.