### PR TITLE
Add upgrading v12 guide

### DIFF
--- a/other-docs/getting-started/README.md
+++ b/other-docs/getting-started/README.md
@@ -70,8 +70,6 @@ For local development, you'll also need to add a local server to your developmen
 
 Local Server requires [Docker Desktop for Mac or Windows](https://www.docker.com/products/docker-desktop), or Docker Engine on Linux.
 
-If you are unable to run Docker Desktop or Docker Engine on your machine you can use the alternative local development environment based on [Chassis](https://chassis.io/). Chassis requires [Vagrant](https://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/).
-
 To set up Local Server for Altis, run the following inside your project's directory:
 
 ```

--- a/other-docs/getting-started/README.md
+++ b/other-docs/getting-started/README.md
@@ -86,6 +86,9 @@ To stop Local Server, run `composer server stop`.
 
 To start the virtual machine again run `composer serve`.
 
+### Docker alternative
+
+If you are unable to use Docker on your computer, consider trying a [GitHub Codespaces environment](docs://dev-tools/cloud-dev-env/), which makes it possible to spin up a complete Altis development environment within your browser, without having to install any additional software on your computer.
 
 ## Ready for development!
 

--- a/other-docs/getting-started/differences-from-wp.md
+++ b/other-docs/getting-started/differences-from-wp.md
@@ -23,7 +23,7 @@ You'll also see a `vendor/` directory, as well as some extra files including `co
 
 With Altis projects, you use [Composer](https://getcomposer.org/) to manage dependencies including Altis and WordPress. You can also [manage plugins and themes via Composer](third-party-plugins.md) if you want.
 
-Your `composer.json` contains your Composer manifest. This describes which libraries and tools to load in. If you've just created a new version of Altis, this will only contain Altis itself (`altis/altis`) as well as the local environments (`altis/local-chassis` and `altis/local-server`). These will be tied to a specific version of Altis (like `^10.0.0`).
+Your `composer.json` contains your Composer manifest. This describes which libraries and tools to load in. If you've just created a new version of Altis, this will only contain Altis itself (`altis/altis`) as well as the local environment (`altis/local-server`). These will be tied to a specific version of Altis (like `^10.0.0`).
 
 The main Altis package (`altis/altis`) will load in a bunch of dependencies, including WordPress and bundled plugins. **The version of WordPress you use is tied to the Altis version**, as are any bundled plugins. This means we can ensure all the functionality works well together. We support each major version [for a full year](docs://guides/long-term-support/) including backporting bugfixes and security patches.
 

--- a/other-docs/guides/getting-help-with-altis/debugging.md
+++ b/other-docs/guides/getting-help-with-altis/debugging.md
@@ -30,7 +30,7 @@ $ composer create-project altis/skeleton my-test-project
 
 (Replace `my-test-project` with any name you like.)
 
-Once created, use [Local Chassis](docs://local-chassis/) or [Local Server](docs://local-server) to run locally, and attempt to replicate the issue.
+Once created, use [Local Server](docs://local-server) to run locally, and attempt to replicate the issue.
 
 We recommend leaving configuration at its default settings initially, and turning on any configuration progressively as necessary.
 

--- a/other-docs/guides/migrating/README.md
+++ b/other-docs/guides/migrating/README.md
@@ -146,7 +146,6 @@ Next, we need to add some extra configuration to allow Altis to set itself up. O
             "altis/cms-installer": true,
             "altis/dev-tools-command": true,
             "altis/core": true,
-            "altis/local-chassis": true,
             "altis/local-server": true
         }
     }
@@ -163,7 +162,7 @@ Now, let's add Altis to your codebase.
 
 Run `composer require altis/altis` from the command line. You'll see Composer install Altis and its dependencies.
 
-Next, run `composer require --dev altis/local-chassis altis/local-server`. You'll see Composer install the [Local Chassis](docs://local-chassis/) and [Local Server](docs://local-server/).
+Next, run `composer require --dev altis/local-server`. You'll see Composer install the [Local Server](docs://local-server/).
 
 Once these have been installed, your codebase will contain some new directories and files, and should look like:
 

--- a/other-docs/guides/migrating/from-hm-platform.md
+++ b/other-docs/guides/migrating/from-hm-platform.md
@@ -158,18 +158,6 @@ composer require --dev altis/local-server
 
 To start the docker server run `composer serve`. You should now be able to see the site at https://my-project.altis.dev where "my-project" is the project directory name.
 
-### Docker alternative
-
-If you are unable to use Docker you can use [Chassis for local development](docs://local-chassis/README.md). You will need to remove the existing Chassis install, and install the Altis module. If you have a setup script (such as `.bin/setup.sh`) you should remove any Chassis setup / installation steps.
-
-Once you have removed any existing Chassis install and related code, install the `altis/local-chassis` composer package as a dev dependency.
-
-```sh
-composer require --dev altis/local-chassis
-```
-
-Once completed, install and start your local server with `composer chassis init` and then `composer chassis start`. You should now be able to navigate to http://my-project.local to see the site, where "my-project" is your project directory name.
-
 ## Migrating from a single site install
 
 Altis is always configured to be a WordPress multisite, as such any sites that are not installed as multisite already, will need converting via the `multisite-convert` WP CLI command. Note that you will need to do this on your Cloud environments after deploying.
@@ -181,9 +169,6 @@ wp core multisite-convert
 
 # On Local Server
 composer server cli core multisite-convert
-
-# On Local Chassis
-composer server exec wp core multisite-convert
 ```
 
 **Important:** Part of the conversion process will reset your main site's permalink structure. You should reset this via the admin Permalinks page immediately.
@@ -195,9 +180,6 @@ wp cache flush
 
 # On Local Server
 composer server cli cache flush
-
-# On Local Chassis
-composer server exec wp cache flush
 ```
 
 There are several key differences between a single site and a multisite install:

--- a/other-docs/guides/migrating/from-hm-platform.md
+++ b/other-docs/guides/migrating/from-hm-platform.md
@@ -158,6 +158,10 @@ composer require --dev altis/local-server
 
 To start the docker server run `composer serve`. You should now be able to see the site at https://my-project.altis.dev where "my-project" is the project directory name.
 
+### Docker alternative
+
+If you are unable to use Docker on your computer, consider trying a [GitHub Codespaces environment](docs://dev-tools/cloud-dev-env/), which makes it possible to spin up a complete Altis development environment within your browser, without having to install any additional software on your computer.
+
 ## Migrating from a single site install
 
 Altis is always configured to be a WordPress multisite, as such any sites that are not installed as multisite already, will need converting via the `multisite-convert` WP CLI command. Note that you will need to do this on your Cloud environments after deploying.

--- a/other-docs/guides/updating-elasticsearch/README.md
+++ b/other-docs/guides/updating-elasticsearch/README.md
@@ -22,7 +22,6 @@ These requirements will help to avoid any errors and delays.
 1. If the upgrade is for a cloud environment, ensure the updated `composer.lock` has been committed and deployed
 1. If any patch updates were downloaded, in particular for the Cloud or Search modules you should reindex your content using one of the following commands:
    - Local Server: `composer server cli -- elasticpress index --setup --network-wide`
-   - Local Chassis: `composer chassis exec -- wp elasticpress index --setup --network-wide`
    - Cloud: `wp elasticpress index --setup --network-wide`
 
 After completing the above steps to ensure your environment is ready for the Elasticsearch upgrade, you can then proceed to the steps below.
@@ -33,19 +32,14 @@ It is recommended to update your local environment's Elasticsearch version befor
 
 1. Take a database back up of your existing local environment using WP CLI:
    - Local Server: `composer server exec -- wp db export database.sql`
-   - Local Chassis: `composer chassis exec -- wp db export database.sql`
 1. Destroy your existing local environment:
    - Local Server: `composer server destroy`
-   - Local Chassis: `composer chassis destroy`
-1. Require Local Server or Local Chassis version 9.0.0 or higher:
+1. Require Local Server version 9.0.0 or higher:
    ```sh
    composer require --dev --update-with-dependencies altis/local-server:^9.0.0
-   composer require --dev --update-with-dependencies altis/local-chassis:^9.0.0
    ```
-1. Upgrade if using Local Chassis by running `composer chassis upgrade`
 1. Start your environment and re-import your data:
    - Local Server: `composer server start && composer server exec -- wp db import database.sql`
-   - Local Chassis: `composer chassis start && composer chassis exec -- wp db import database.sql`
 
 **Note:** These local environment versions should be backwards compatible with older Altis versions but it is not guaranteed. Contact support if you experience issues.
 

--- a/other-docs/guides/upgrading/v12.md
+++ b/other-docs/guides/upgrading/v12.md
@@ -45,6 +45,10 @@ Altis v12 fully supports PHP 8.0 in both local and cloud environments. Support f
 
 Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date compatibility, testing and upgrading information.
 
+### Asset Loader ###
+
+We've updated the humanmade/asset-loader dependency from 0.5.0 to 0.6.1. As part of this change, the following previously deprecated methods in the asset-loader were removed: `autoregister`, `autoenqueue`, and `register_assets`. If your Altis project is using the asset-loader library directly, it is recommended to run a search for these functions across your codebase when upgrading to Altis v12.
+
 ## Headline Features
 
 ### Codespaces Support ###

--- a/other-docs/guides/upgrading/v12.md
+++ b/other-docs/guides/upgrading/v12.md
@@ -1,0 +1,54 @@
+---
+order: 12
+---
+# Upgrading to v12
+
+_If you are migrating from WordPress to Altis, check out the [migrating guide here](../migrating-from-wordpress.md) first._
+
+To upgrade to Altis v12, edit your `composer.json` and change the version constraint for `altis/altis` and any local environment modules to `^12.0.0`.
+
+```json
+{
+	"require": {
+		"altis/altis": "^12.0.0"
+	},
+	"require-dev": {
+		"altis/local-chassis": "^12.0.0",
+		"altis/local-server": "^12.0.0"
+	},
+	"config": {
+		"platform": {
+			"php": "8.0"
+		}
+	}
+}
+```
+
+Once you have made these changes run `composer update` and then run the `wp altis migrate` command:
+
+```sh
+# For cloud environments
+wp altis migrate
+
+# For local server
+composer server cli -- altis migrate
+
+# For local chassis
+composer chassis exec -- wp altis migrate
+```
+
+## Breaking Changes
+
+### PHP 8.0 ###
+
+Altis v12 fully supports PHP 8.0 in both local and cloud environments. Support for earlier versions of PHP has been deprecated and will be removed in future versions. There are plenty of [backward incompatible changes](https://www.php.net/manual/en/migration80.incompatible.php) in PHP 8.0 which should be addressed. Local Server will also run PHP 8.0 by default unless version 7.4 is [explicitly requested](docs://local-server/php-version/).
+
+Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date compatibility, testing and upgrading information.
+
+## Headline Features
+
+### Codespaces Support ###
+
+Altis now has support for [GitHub Codespaces](https://github.com/features/codespaces), which is a cloud-based development environment directly inside the browser. This makes it possible to quickly launch and work on Altis projects without having to install any of the development tools on your local computer. It also allows you to share preview environments with colleagues.
+
+Visit our complete guide to [get started with Altis in Codespaces](docs://dev-tools/cloud-dev-env/).

--- a/other-docs/guides/upgrading/v12.md
+++ b/other-docs/guides/upgrading/v12.md
@@ -13,7 +13,6 @@ To upgrade to Altis v12, edit your `composer.json` and change the version constr
 		"altis/altis": "^12.0.0"
 	},
 	"require-dev": {
-		"altis/local-chassis": "^12.0.0",
 		"altis/local-server": "^12.0.0"
 	},
 	"config": {
@@ -32,9 +31,6 @@ wp altis migrate
 
 # For local server
 composer server cli -- altis migrate
-
-# For local chassis
-composer chassis exec -- wp altis migrate
 ```
 
 ## Breaking Changes
@@ -48,6 +44,18 @@ Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date com
 ### Asset Loader ###
 
 We've updated the humanmade/asset-loader dependency from 0.5.0 to 0.6.1. As part of this change, the following previously deprecated methods in the asset-loader were removed: `autoregister`, `autoenqueue`, and `register_assets`. If your Altis project is using the asset-loader library directly, it is recommended to run a search for these functions across your codebase when upgrading to Altis v12.
+
+### Deprecating Local Chassis ###
+
+We are deprecating and discontinuing support for the Local Chassis development environment in Altis v12. The newer [Local Server](docs://local-server/) should be the go-to environment for all Altis development going forward. This means that the `require-dev` section in the project's `composer.json` should no longer list `altis/local-chassis` and should only use `altis/local-server` instead:
+
+```json
+	"require-dev": {
+		"altis/local-server": "^12.0.0"
+	},
+```
+
+Note that Local Server will not automatically inherit or import any data from existing Chassis environments. Any files or database migrations between development environments will have to be done manually.
 
 ## Headline Features
 

--- a/other-docs/guides/upgrading/v12.md
+++ b/other-docs/guides/upgrading/v12.md
@@ -5,7 +5,7 @@ order: 12
 
 _If you are migrating from WordPress to Altis, check out the [migrating guide here](../migrating-from-wordpress.md) first._
 
-To upgrade to Altis v12, edit your `composer.json` and change the version constraint for `altis/altis` and any local environment modules to `^12.0.0`.
+To upgrade to Altis v12, edit your `composer.json` and change the version constraint for `altis/altis` and any local environment modules to `^12.0.0`. Note that the new default and recommended version of PHP for Altis v12 is now 8.0. Make sure you have tested your custom code and any additional plugins for compatibility with [PHP version 8.0](#php-80).
 
 ```json
 {


### PR DESCRIPTION
Adds an upgrading to Altis v12 guide.

See: https://github.com/humanmade/product-dev/issues/1095