### PR TITLE
Clarify that 2FA became required in V11

### DIFF
--- a/other-docs/guides/upgrading/v11.md
+++ b/other-docs/guides/upgrading/v11.md
@@ -49,6 +49,10 @@ ElasticPress has been updated to version 4.0 and will require a full reindex aft
 
 [HSTS can be switched off via the Altis config by following the documentation here](docs://security/browser.md#strict-transport-policy).
 
+### Two-Factor Authentication Now Required by Default for Administrator Roles
+
+[Two-Factor Authentication](docs://security/2-factor-authentication.md) is now required by default for Administrators and network Super-Admins. This may be customized using the Altis configuration as documented in the security module.
+
 ## PHP 8 Readiness
 
 PHP 8.0 will be made available in the upcoming Altis v12 release for local and cloud environments.


### PR DESCRIPTION
The upgrade guide made no mention of this, which caught out an Altis client when they jumped from V10-V12. This adds an appropriate note on V11, which coincides with when the default changed in the security module.