### PR TITLE
Fix broken links in upgrading doc

### DIFF
--- a/other-docs/guides/upgrading/v14.md
+++ b/other-docs/guides/upgrading/v14.md
@@ -47,7 +47,7 @@ plugins instead. This includes the third-party plugins we bundle, as well as a s
 
 These changes will allow us to deliver more value faster, and will provide you with more control over upgrades.
 
-Features provided in earlier versions will continue to be supported per our [long-term support policy](/guides/long-term-support.md).
+Features provided in earlier versions will continue to be supported per our [long-term support policy](docs://guides/long-term-support.md).
 
 ### Digital experience tools are moving to a plugin
 
@@ -127,7 +127,7 @@ require_once __DIR__ . '/vendor/humanmade/delegated-oauth/plugin.php';
 The Multilingual Module has been removed from Altis v14. This provided no
 specific functionality. Rather some documented guidance. To add multilingual
 capability to your Altis project you can continue
-to [use off-the-shelf plugins](/getting-started/third-party-plugins/)
+to [use off-the-shelf plugins](docs://getting-started/third-party-plugins/)
 such as [MultilingualPress](https://multilingualpress.org/).
 
 #### Authorship
@@ -254,7 +254,7 @@ A number of modules and libraries have been updated to incorporate important bug
 ### Documentation 
 
 Some of our developer focussed documentation hase been clarified and improved, taking on board feedback from our customers and partners. 
-There is now a [documentation lint command](/dev-tools/linting-your-documents/) for your custom modules.
+There is now a [documentation lint command](docs://dev-tools/linting-your-documents/) for your custom modules.
 
 ### Altis CLI
 


### PR DESCRIPTION
This fixes a couple of broken l;inks in the published v14 upgrading document.
