### PR TITLE
Add note on removal of duplicate post

### DIFF
--- a/other-docs/guides/upgrading/v14.md
+++ b/other-docs/guides/upgrading/v14.md
@@ -105,6 +105,18 @@ checklist. If you want to use the previous Altis demo functionality as a
 starting point, take a look at
 the [Demo GitHub repository](https://github.com/humanmade/demo-publication-checklist)
 
+#### Clone & Amend
+
+The Clone & Amend feature has been removed from Altis v14. You can keep this functionality by including the Duplicate Post plugin by Yoast, from the `composer require yoast/duplicate-post` package. Note that the naming of the features is a little different. The differences are as follows: 
+
+- Clone -> Copy to a new draft
+- Create an amendment -> Rewrite and Republish
+
+```sh
+# Add publication checklist example
+composer require "yoast/duplicate-post"
+```
+
 #### WordPress SSO
 
 Altis no longer natively supports using an external WordPress site as a Single


### PR DESCRIPTION
Duplicate post was also removed with workflow module in v14 and is a popular feature for clients on Altis.

It's missing from the upgrade guide currently.