### PR TITLE
Fix references to wpackagist

### DIFF
--- a/other-docs/guides/upgrading/v14.md
+++ b/other-docs/guides/upgrading/v14.md
@@ -79,7 +79,7 @@ package.
 
 ```sh
 # Add Workflows package
-composer require "humanmade/workflows"
+composer require humanmade/workflows
 ```
 
 This provides the framework to create your own workflow as well as the
@@ -96,7 +96,7 @@ can install the off-the-shelf plugin in your project's `composer.json` file.
 
 ```shell
 ## Add the Yoast Duplicate Post plugin
-composer require "wppackagist/duplicate-post"
+composer require wpackagist-plugin/duplicate-post
 ```
 
 Note: The plugin uses the terms "Clone" and "Copy to a new draft" instead of "Clone" and "Rewrite & Republish" instead of
@@ -110,7 +110,7 @@ package to your project.
 
 ```sh
 # Add publication checklist example
-composer require "humanmade/publication-checklist"
+composer require humanmade/publication-checklist
 ```
 
 This will provide you with the framework to write your own publication
@@ -151,7 +151,7 @@ package to your project.
 
 ```sh
 # Add publication checklist example
-composer require "humanmade/authorship"
+composer require humanmade/authorship
 ```
 
 #### Robots.txt Support
@@ -204,7 +204,7 @@ off-the-shelf plugin in your projects `composer.json` file.
 
 ```shell
 ## Add the Yoast SEO plugin
-composer require "wppackagist/wordpress-seo"
+composer require wpackagist-plugin/wordpress-seo
 ```
 
 If you are using the premium version of the plugin, follow
@@ -224,7 +224,7 @@ add [humanmade/Gaussholder](https://github.com/humanmade/Gaussholder) to your pr
 
 ```bash
 ## Add Gaussholder library
-composer require "humanmade/gaussholder"
+composer require humanmade/gaussholder
 ```
 
 Then hook into the `gaussholder.image_sizes` filter.


### PR DESCRIPTION
The composer package names referencing wpackagist were incorrect, and there was some inconsistency with the use of quotes in composer require commands. They're not necessary.