### PR TITLE
Document v17 upgrade guide and other docs

### DIFF
--- a/other-docs/guides/migrating/README.md
+++ b/other-docs/guides/migrating/README.md
@@ -85,12 +85,10 @@ Currently, Altis bundles the following plugins:
 - `consent-api`
 - `clean-html`
 - `debug-bar-elasticpress`
-- `delegated-oauth`
 - `elasticpress`
 - `hm-gtm`
 - `hm-redirects`
 - `ludicrousdb`
-- `meta-tags`
 - `query-monitor`
 - `require-login`
 - `safe-svg`
@@ -132,8 +130,8 @@ Next, we need to add some extra configuration to allow Altis to set itself up. O
     },
     "config": {
         "platform": {
-            "php": "8.0",
-            "ext-mbstring": "8.0"
+            "php": "8.1",
+            "ext-mbstring": "8.1"
         },
         "allow-plugins": {
             "composer/installers": true,

--- a/other-docs/guides/updating-php/README.md
+++ b/other-docs/guides/updating-php/README.md
@@ -9,14 +9,15 @@ There are 2 key steps to getting ready for a new version of PHP:
 
 ## Altis Compatibility Chart
 
-**Note:** PHP 8.0 is officially available from Altis v12 onwards.
 
-| Altis | PHP 7.4      | PHP 8.0       | PHP 8.1       | PHP 8.2        |
-|-------|--------------|---------------|---------------|----------------|
-| v15   |              | **Supported** | **Supported** | *Experimental* |
-| v14   |              | **Supported** | **Supported** |                |
-| v13   |              | **Supported** | **Supported** |                |
-| v12   | *Deprecated* | **Supported** | **Supported** |                |
+| Altis  | PHP 8.0       | PHP 8.1       | PHP 8.2        |
+|--------|---------------|---------------|----------------|
+| v17    | **Supported** | **Supported** | *Experimental* |
+| v16    | **Supported** | **Supported** | *Experimental* |
+| v15    | **Supported** | **Supported** | *Experimental* |
+| v14    | **Supported** | **Supported** |                |
+| v13    | **Supported** | **Supported** |                |
+
 
 ## Checking PHP Version Compatibiliity
 
@@ -30,7 +31,7 @@ In your `composer.json` you may have some code like the following:
 {
     "config": {
         "platform": {
-            "php": "7.4"
+            "php": "8.1"
         }
     }
 }
@@ -70,11 +71,11 @@ First install the standard and dependencies using the following command:
 composer global require dealerdirect/phpcodesniffer-composer-installer phpcompatibility/php-compatibility
 ```
 
-Next run the standard against your codebase for the target PHP version, in this example PHP 8.0:
+Next run the standard against your codebase for the target PHP version, in this example PHP 8.1:
 
 ```
 phpcs -p --standard=PHPCompatibility \
-  --runtime-set testVersion 8.0 \
+  --runtime-set testVersion 8.1 \
   --extensions=php \
   -d memory_limit=1G \
   --ignore=wordpress,vendor/altis,\*/tests/\* .
@@ -102,7 +103,7 @@ You can add these to the ignored directories in the command when checking if des
 
 Once you are confident that your application is compatible with the version of PHP to upgrade to you should do the following for each environment:
 
-1. Create a support ticket for the target environment with the type "Task", titled "Upgrade to PHP 8.0", replacing "8.0" with the target version if necessary ( noting that the updated PHP version will not be deployed automatically until the next application deployment ).
+1. Create a support ticket for the target environment with the type "Task", titled "Upgrade to PHP 8.1", replacing "8.1" with the target version if necessary ( noting that the updated PHP version will not be deployed automatically until the next application deployment ).
 2. Wait for the Altis team to confirm the environment has been updated.
 3. Deploy the updated application code.
 
@@ -124,7 +125,7 @@ Additionally, we recommend setting the PHP version explicitly, which will ensure
 The easiest way to add this is to run:
 
 ```sh
-composer config platform.php 8.0
+composer config platform.php 8.1
 ```
 
-(Replace 8.0 with your desired new PHP version.)
+(Replace 8.1 with your desired new PHP version.)

--- a/other-docs/guides/upgrading/README.md
+++ b/other-docs/guides/upgrading/README.md
@@ -8,17 +8,17 @@ _If you are migrating an existing install to Altis check out the [migrating guid
 
 When new versions of Altis are released you will need to manually upgrade your project to the new version. New versions can bring anything from breaking changes to new features. It's important you read the changelog / upgrade notes for the specific version you are upgrading to. When upgrading multiple versions at once, be sure to follow the release notes on all intermediate versions.
 
-To switch the version of Altis for your project, modify the version constraint for the `altis/altis` dependency in your `composer.json`. For example, to upgrade to Altis version 2.
+To switch the version of Altis for your project, modify the version constraint for the `altis/altis` dependency in your `composer.json`. For example, to upgrade to Altis version 17.
 
 ```json
 {
 	"name": "company-name/my-site",
 	"require": {
-		"altis/altis": "^2.0.0"
+		"altis/altis": "^17.0.0"
 	},
 	"require-dev": {
-		"altis/local-chassis": "^2.0.0",
-		"altis/local-server": "^2.0.0"
+		"altis/local-chassis": "^17.0.0",
+		"altis/local-server": "^17.0.0"
 	}
 }
 ```
@@ -35,6 +35,7 @@ Any upgrade will usually require some modification to your project (for example,
 
 ## Upgrade Guides
 
+- [Version 17](./v17.md)
 - [Version 16](./v16.md)
 - [Version 15](./v15.md)
 - [Version 14](./v14.md)

--- a/other-docs/guides/upgrading/v17.md
+++ b/other-docs/guides/upgrading/v17.md
@@ -39,6 +39,26 @@ composer server cli -- altis migrate
 
 ## Breaking Changes
 
+## Changes to the Altis platform
+
+We have removed the Analytics module, Experience Blocks and Global Blocks from
+the Altis platform. These are now delivered through the new Altis Accelerate
+plugin. Learn more at https://www.altis-dxp.com/accelerate/.
+
+This change will allow us to deliver more value faster, and will provide you
+with more control over upgrades.
+
+Features provided in earlier versions will continue to be supported per
+our [long-term support policy](docs://guides/long-term-support.md).
+
+The original features are currently still available as a standalone plugin.
+You can include it by adding it as a dependency in your top-level `composer.json` file.
+
+```sh
+# Add Extended CPTs support
+composer require altis/analytics
+```
+
 ### PHP 8.1
 
 PHP 8.1 is now our recommended version of PHP for Altis. We have improved

--- a/other-docs/guides/upgrading/v17.md
+++ b/other-docs/guides/upgrading/v17.md
@@ -52,7 +52,8 @@ Features provided in earlier versions will continue to be supported per
 our [long-term support policy](docs://guides/long-term-support.md).
 
 The original features are currently still available as a standalone plugin.
-You can include it by adding it as a dependency in your top-level `composer.json` file.
+You can include it by adding it as a dependency in your
+top-level `composer.json` file.
 
 ```sh
 # Add Extended CPTs support
@@ -94,18 +95,6 @@ including:
 See
 the [WordPress 6.3 Field Guide](https://make.wordpress.org/core/2023/07/18/wordpress-6-3-field-guide/)
 for more information.
-
-### Afterburner
-
-[TO DO] Mention updates to caching.
-[TO DO] Add mention of updates to translations??
-
-We created our own PHP extension just to optimise WordPress performance. We’ve
-taken the slowest, most-used parts of WordPress, and reimplemented them to
-squeeze every drop of performance out of your site.
-
-To activate Afterburner on your
-environment, [create a support ticket](support://new) with the request.
 
 ### Altis Core improvements
 

--- a/other-docs/guides/upgrading/v17.md
+++ b/other-docs/guides/upgrading/v17.md
@@ -1,0 +1,91 @@
+---
+order: 17
+---
+
+# Upgrading to v17
+
+_If you are migrating from WordPress to Altis, check out
+the [migrating guide](../migrating/) first._
+
+To upgrade to Altis v17, edit your `composer.json` and change the version
+constraint for `altis/altis` and any local environment modules to `^17.0.0`.
+
+```json
+{
+	"require": {
+		"altis/altis": "^17.0.0"
+	},
+	"require-dev": {
+		"altis/local-server": "^17.0.0"
+	},
+	"config": {
+		"platform": {
+			"php": "8.1"
+		}
+	}
+}
+```
+
+Once you have made these changes run `composer update` and then run
+the `wp altis migrate` command:
+
+```sh
+# For cloud environments
+wp altis migrate
+
+# For local server
+composer server cli -- altis migrate
+```
+
+## Breaking Changes
+
+### PHP 8.2 ###
+
+Altis v17 continues our experimental support for PHP 8.2 in both local and cloud
+environments. We have improved compatability with PHP 8.2 (and 8.1) but there
+are a number
+of [backward incompatible changes](https://www.php.net/manual/en/migration82.
+incompatible.php) in PHP 8.2 which you should take into consideration.
+
+Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date
+compatibility, testing and upgrading information.
+
+## Headline Features
+
+### WordPress 6.3.1
+
+WordPress 6.3.1 brings a number of new features, bug fixes, and improvements,
+including:
+
+- the Block Selectors API,
+- the WordPress Command Palette,
+- updates to the Social Icons block,
+- improvements to the cache API,
+- and multiple performance improvements.
+
+See
+the [WordPress 6.3 Field Guide](https://make.wordpress.org/core/2023/07/18/wordpress-6-3-field-guide/)
+for more information.
+
+### Afterburner
+
+[TO DO] Mention updates to caching.
+[TO DO] Add mention of updates to translations??
+
+We created our own PHP extension just to optimise WordPress performance. We’ve
+taken the slowest, most-used parts of WordPress, and reimplemented them to
+squeeze every drop of performance out of your site.
+
+To activate Afterburner on your
+environment, [create a support ticket](support://new) with the request.
+
+### Altis Core improvements
+
+We have incorporated many updates to modules and libraries in Altis to bring in 
+important bug fixes and improvements.
+
+### Documentation
+
+Our developer focussed documentation has been improved again. As usual, feedback
+from our customers and partners is always welcome.
+Please [send us any feedback you have](mailto://support@altis-dxp.com).

--- a/other-docs/guides/upgrading/v17.md
+++ b/other-docs/guides/upgrading/v17.md
@@ -39,6 +39,14 @@ composer server cli -- altis migrate
 
 ## Breaking Changes
 
+### PHP 8.1
+
+PHP 8.1 is now our recommended version of PHP for Altis. We have improved
+support for it but note that there are a number of exceptions to
+compatability in the core WordPress CMS module. See the [WordPress
+documentation on compatibility](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/)
+for more information.
+
 ### PHP 8.2 ###
 
 Altis v17 continues our experimental support for PHP 8.2 in both local and cloud
@@ -81,7 +89,7 @@ environment, [create a support ticket](support://new) with the request.
 
 ### Altis Core improvements
 
-We have incorporated many updates to modules and libraries in Altis to bring in 
+We have incorporated many updates to modules and libraries in Altis to bring in
 important bug fixes and improvements.
 
 ### Documentation


### PR DESCRIPTION
Updated the PHP supported versions to mention v17 and dropped v12.
Removed mention of plugins we no longer ship.
Updated example PHP versions to be 8.1
Updated example Altis version to 17.
Added v17 upgrade guide.
Documented removal of the Analytics module.
