### PR TITLE
A17 feedback link

### DIFF
--- a/other-docs/guides/upgrading/v17.md
+++ b/other-docs/guides/upgrading/v17.md
@@ -128,4 +128,4 @@ important bug fixes and improvements.
 
 Our developer focussed documentation has been improved again. As usual, feedback
 from our customers and partners is always welcome.
-Please [send us any feedback you have](mailto://support@altis-dxp.com).
+Please [send us any feedback you have](mailto:support@altis-dxp.com).


### PR DESCRIPTION
The feedback link on the Altis 17 upgrade page is broken because it's invalid. I used the edit link which branched off the `v17-branch` FYI.