### PR TITLE
Content Migration command conflict

### DIFF
--- a/other-docs/guides/launching-a-site-on-altis.md
+++ b/other-docs/guides/launching-a-site-on-altis.md
@@ -120,7 +120,7 @@ When the most updated data has been imported into the database, a search-and-rep
 The following command would change all entries in the database containing `domain-production.altis.cloud` to `domain.com`. We recommend testing the change first using the `--dry-run` flag to make sure no unexpected tables are affected.
 
 ```bash
-wp search-replace domain-production.altis.cloud domain.com --all-tables --network --url=domain-production.altis.cloud
+wp search-replace domain-production.altis.cloud domain.com --network
 ```
 
 This step will need to be repeated for any subdomains you have. Be sure to flush the cache when you are done, otherwise the old URLs will still be saved in the object cache.


### PR DESCRIPTION
The all-tables, url and network arguments conflict with one another.

I understand optionally the --all-tables will update any non-core WP tables, for example those created by plugins. But a command can't run on the network and a single site at the same time, so I assume the url parameter here is ignored?

--all-tables overrides --network.