### PR TITLE
Upgrading Guide for Altis v20

### DIFF
--- a/other-docs/guides/upgrading/README.md
+++ b/other-docs/guides/upgrading/README.md
@@ -12,16 +12,16 @@ specific version you are upgrading to. When upgrading multiple versions at once,
 all intermediate versions.
 
 To switch the version of Altis for your project, modify the version constraint for the `altis/altis` dependency in
-your `composer.json`. For example, to upgrade to Altis version 19.
+your `composer.json`. For example, to upgrade to Altis version 20.
 
 ```json
 {
     "name": "company-name/my-site",
     "require": {
-        "altis/altis": "^19.0.0"
+        "altis/altis": "^20.0.0"
     },
     "require-dev": {
-        "altis/local-server": "^19.0.0"
+        "altis/local-server": "^20.0.0"
     }
 }
 ```
@@ -43,6 +43,7 @@ with "BREAKING: " in the version release notes.
 
 ## Upgrade Guides
 
+- [Version 20](./v20.md)
 - [Version 19](./v19.md)
 - [Version 18](./v18.md)
 - [Version 17](./v17.md)

--- a/other-docs/guides/upgrading/v20.md
+++ b/other-docs/guides/upgrading/v20.md
@@ -39,14 +39,14 @@ composer server cli -- altis migrate
 
 ## Changes to the Altis platform
 
-Altis dev tools now come with wp-browser 4.x and Codeception 5.x This upgrade has some breaking changes. Please refer to
+Altis dev tools now come with `wp-browser` 4.x and `Codeception` 5.x This upgrade has some breaking changes. Please refer to
 the [wp-browser release notes](https://github.com/lucatume/wp-browser/releases/tag/4.0.0)
-and [Codeception release post ](https://codeception.com/07-28-2022/codeception-5.html)
+and [Codeception release post](https://codeception.com/07-28-2022/codeception-5.html)
 
 ## PHP
 
 We have added experimental support for PHP 8.3. This is not yet recommended for production use but you can test your code with
-PHP 8.3 in local server
+PHP 8.3 in [Local Server](docs://local-server/).
 
 Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date compatibility, testing and upgrading information.
 
@@ -60,9 +60,9 @@ we welcome feedback.
 
 ### WordPress 6.6.1
 
-WordPress 6.6 brings lots of new features, bug fixes, and improvements across the board. In particular, there are improvemnets
+WordPress 6.6 brings lots of new features, bug fixes, and improvements across the board. In particular, there are improvements
 in performance and accessibility, and new features and updates for the block editor (Gutenberg) and the block API.
-There have been theming improvements of interest to theme developers and designers
+There have been theming improvements of interest to theme developers and designers.
 For developers, the Options API has been improved again, allowing more flexibility in fine-tuning your application performance.
 WordPress 6.6 also drops support for PHP7.0 and 7.1 but given Altis doesn't support PHP 7 at all, this will not affect your
 Altis sites. A number of new filter and action hooks have been added and improvements to modernise the code and apply coding
@@ -73,9 +73,9 @@ See the
 
 ### Altis Core improvements
 
-Altis dev tools now come with wp-browser 4 and Codeception 5. This brings full support for PHP 8+. As well as improvements to
+Altis dev tools now come with `wp-browser` 4 and `Codeception` 5. This brings full support for PHP 8+. As well as improvements to
 both tools. See the [wp-browser release notes](https://github.com/lucatume/wp-browser/releases/tag/4.0.0)
-and [Codeception release post ](https://codeception.com/07-28-2022/codeception-5.html)
+and [Codeception release post](https://codeception.com/07-28-2022/codeception-5.html)
 
 Local server now supports TablePlus as well as Sequel Ace.
 
@@ -83,5 +83,5 @@ We have incorporated many updates to modules and libraries in Altis to bring in 
 
 ### Documentation
 
-Our developer focussed documentation has been improved again. As usual, feedback from our customers and partners is always welcome.
+Our developer focused documentation has been improved again. As usual, feedback from our customers and partners is always welcome.
 Please [send us any feedback you have](mailto:support@altis-dxp.com).

--- a/other-docs/guides/upgrading/v20.md
+++ b/other-docs/guides/upgrading/v20.md
@@ -1,0 +1,87 @@
+---
+order: 20
+---
+
+# Upgrading to v20
+
+*If you are migrating from WordPress to Altis, check out the [migrating guide](../migrating/) first.*
+
+To upgrade to Altis v20, edit your `composer.json` and change the version constraint for `altis/altis` and any local environment
+modules to `^20.0.0`.
+
+```json
+{
+    "require": {
+        "altis/altis": "^20.0.0"
+    },
+    "require-dev": {
+        "altis/local-server": "^20.0.0"
+    },
+    "config": {
+        "platform": {
+            "php": "8.2"
+        }
+    }
+}
+```
+
+Once you have made these changes, run `composer update` and then run the `wp altis migrate` command:
+
+```sh
+# For cloud environments
+wp altis migrate
+
+# For local server
+composer server cli -- altis migrate
+```
+
+## Breaking Changes
+
+## Changes to the Altis platform
+
+Altis dev tools now come with wp-browser 4.x and Codeception 5.x This upgrade has some breaking changes. Please refer to
+the [wp-browser release notes](https://github.com/lucatume/wp-browser/releases/tag/4.0.0)
+and [Codeception release post ](https://codeception.com/07-28-2022/codeception-5.html)
+
+## PHP
+
+We have added experimental support for PHP 8.3. This is not yet recommended for production use but you can test your code with
+PHP 8.3 in local server
+
+Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date compatibility, testing and upgrading information.
+
+## Headline Features
+
+## Node.js
+
+Altis now supports running Node.js applications alongside WordPress, utilizing WordPress as a headless API. See [our Node.js
+documentation](docs://cloud/nodejs/) for more information. This is an experimental feature, you can enable it in Local Server, and
+we welcome feedback.
+
+### WordPress 6.6.1
+
+WordPress 6.6 brings lots of new features, bug fixes, and improvements across the board. In particular, there are improvemnets
+in performance and accessibility, and new features and updates for the block editor (Gutenberg) and the block API.
+There have been theming improvements of interest to theme developers and designers
+For developers, the Options API has been improved again, allowing more flexibility in fine-tuning your application performance.
+WordPress 6.6 also drops support for PHP7.0 and 7.1 but given Altis doesn't support PHP 7 at all, this will not affect your
+Altis sites. A number of new filter and action hooks have been added and improvements to modernise the code and apply coding
+standards have been made.
+
+See the
+[WordPress 6.6 Field Guide](https://make.wordpress.org/core/2024/06/25/wordpress-6-6-field-guide/) for more information.
+
+### Altis Core improvements
+
+Altis dev tools now come with wp-browser 4 and Codeception 5. This brings full support for PHP 8+. As well as improvements to
+both tools. See the [wp-browser release notes](https://github.com/lucatume/wp-browser/releases/tag/4.0.0)
+and [Codeception release post ](https://codeception.com/07-28-2022/codeception-5.html)
+
+Local server now supports TablePlus as well as Sequel Ace.
+
+We have incorporated many updates to modules and libraries in Altis to bring in important bug fixes and improvements.
+
+### Documentation
+
+Our developer focussed documentation has been improved again. As usual, feedback from our customers and partners is always welcome.
+Please [send us any feedback you have](mailto:support@altis-dxp.com).


### PR DESCRIPTION
Added upgrading guide.
Changed examples to use version 20.
Addresses https://github.com/humanmade/product-dev/issues/1602