### PR TITLE
Docs: Remove duplicated Node.js section from v20 upgrade guide

### DIFF
--- a/other-docs/guides/upgrading/v20.md
+++ b/other-docs/guides/upgrading/v20.md
@@ -72,17 +72,6 @@ standards have been made.
 See the
 [WordPress 6.6 Field Guide](https://make.wordpress.org/core/2024/06/25/wordpress-6-6-field-guide/) for more information.
 
-WordPress 6.6 brings lots of new features, bug fixes, and improvements across the board. In particular, there are improvements
-in performance and accessibility, and new features and updates for the block editor (Gutenberg) and the block API.
-There have been theming improvements of interest to theme developers and designers.
-For developers, the Options API has been improved again, allowing more flexibility in fine-tuning your application performance.
-WordPress 6.6 also drops support for PHP7.0 and 7.1 but given Altis doesn't support PHP 7 at all, this will not affect your
-Altis sites. A number of new filter and action hooks have been added and improvements to modernise the code and apply coding
-standards have been made.
-
-See the
-[WordPress 6.6 Field Guide](https://make.wordpress.org/core/2024/06/25/wordpress-6-6-field-guide/) for more information.
-
 ### Altis Core improvements
 
 Altis dev tools now come with `wp-browser` 4 and `Codeception` 5. This brings full support for PHP 8+. As well as improvements to

--- a/other-docs/guides/upgrading/v20.md
+++ b/other-docs/guides/upgrading/v20.md
@@ -52,15 +52,7 @@ Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date com
 
 ## Headline Features
 
-## Node.js
-
-Altis now supports running Node.js applications alongside WordPress, utilizing WordPress as a headless API. See [our Node.js
-documentation](docs://cloud/nodejs/) for more information. This is an experimental feature, you can enable it in Local Server, and
-we welcome feedback.
-
-### WordPress 6.6.1
-
-## Node.js
+### Node.js
 
 Altis now supports running Node.js applications alongside WordPress, utilizing WordPress as a headless API. See [our Node.js
 documentation](docs://cloud/nodejs/) for more information. This is an experimental feature, you can enable it in Local Server, and

--- a/other-docs/guides/upgrading/v20.md
+++ b/other-docs/guides/upgrading/v20.md
@@ -74,7 +74,7 @@ See the
 
 ### Altis Core improvements
 
-Altis dev tools now come with `wp-browser` 4 and `Codeception` 5. This brings full support for PHP 8+. As well as improvements to
+Altis dev tools now come with `wp-browser` 4 and `Codeception` 5. This brings full support for PHP 8+, as well as improvements to
 both tools. See the [wp-browser release notes](https://github.com/lucatume/wp-browser/releases/tag/4.0.0)
 and [Codeception release post](https://codeception.com/07-28-2022/codeception-5.html)
 


### PR DESCRIPTION
Node.js should be a subheading inside Headline Features, and should not repeat.