### PR TITLE
Fix links to migrating guide

### DIFF
--- a/other-docs/getting-started/differences-from-wp.md
+++ b/other-docs/getting-started/differences-from-wp.md
@@ -110,7 +110,7 @@ local environments, we bundle [Query Monitor](docs://dev-tools/) and extend it w
 
 ## Migrating an existing WordPress site to Altis
 
-We have [a step-by-step guide to moving an existing WordPress site](docs://guides/migrating-from-wordpress/). This will walk you
+We have [a step-by-step guide to moving an existing WordPress site](docs://guides/migrating/). This will walk you
 through converting an existing codebase across to Altis.
 
 Our [launch guidance](docs://guides/launching-a-site-on-altis/) covers how to migrate your database and uploads across to Altis as

--- a/other-docs/guides/README.md
+++ b/other-docs/guides/README.md
@@ -3,5 +3,5 @@
 ![Guides banner](./assets/banner-guides.png)
 
 Altis Guides are here to help you with meta issues and larger tasks that don't fit in to any specific module. Here you can find help
-with [how to upgrade](./upgrading/README.md), [how to migrate to Altis](./migrating-from-wordpress.md),
+with [how to upgrade](./upgrading/README.md), [how to migrate to Altis](docs://guides/migrating/),
 [how to use Altis as a headless CMS](./headless/), [how to automate updates](./automatic-updates.md) and more.


### PR DESCRIPTION
Fixes links to the renamed migrating guide page.

Fixes:https://github.com/humanmade/altis-documentation/issues/477