### PR TITLE
Replace mailto links with support links

### DIFF
--- a/other-docs/guides/upgrading/v14.md
+++ b/other-docs/guides/upgrading/v14.md
@@ -269,7 +269,7 @@ partners. There is now a [documentation lint command](docs://dev-tools/linting-y
 ### Altis CLI
 
 We have launched a new tool, Altis CLI for running Altis utilities and commands. It is currently in beta and we would
-love you to try it out and [send us any feedback](mailto:support@altis-dxp.com).
+love you to try it out and [send us any feedback](support://new).
 
 To install it, you need `node` version v18 or later.
 

--- a/other-docs/guides/upgrading/v16.md
+++ b/other-docs/guides/upgrading/v16.md
@@ -67,4 +67,4 @@ This includes the WordPress CMS, which we updated to version 6.2.2.
 ### Documentation
 
 Our developer focussed documentation has been improved again. As usual, feedback from our
-customers and partners is always welcome. Please [send us any feedback you have](mailto:support@altis-dxp.com).
+customers and partners is always welcome. Please [send us any feedback you have](support://new).

--- a/other-docs/guides/upgrading/v17.md
+++ b/other-docs/guides/upgrading/v17.md
@@ -142,4 +142,4 @@ important bug fixes and improvements.
 
 Our developer focussed documentation has been improved again. As usual, feedback
 from our customers and partners is always welcome.
-Please [send us any feedback you have](mailto:support@altis-dxp.com).
+Please [send us any feedback you have](support://new).

--- a/other-docs/guides/upgrading/v19.md
+++ b/other-docs/guides/upgrading/v19.md
@@ -91,4 +91,4 @@ We have incorporated many updates to modules and libraries in Altis to bring in 
 
 Our developer focussed documentation has been improved again. As usual, feedback
 from our customers and partners is always welcome.
-Please [send us any feedback you have](mailto:support@altis-dxp.com).
+Please [send us any feedback you have](support://new).

--- a/other-docs/guides/upgrading/v20.md
+++ b/other-docs/guides/upgrading/v20.md
@@ -85,4 +85,4 @@ We have incorporated many updates to modules and libraries in Altis to bring in 
 ### Documentation
 
 Our developer focused documentation has been improved again. As usual, feedback from our customers and partners is always welcome.
-Please [send us any feedback you have](mailto:support@altis-dxp.com).
+Please [send us any feedback you have](support://new).

--- a/other-docs/guides/upgrading/v21.md
+++ b/other-docs/guides/upgrading/v21.md
@@ -88,4 +88,4 @@ and improvements.
 ### Documentation
 
 Our developer focused documentation has been improved again. As usual, feedback from our customers and partners is always welcome.
-Please [send us any feedback you have](mailto:support@altis-dxp.com).
+Please [send us any feedback you have](support://new).

--- a/user-docs/README.md
+++ b/user-docs/README.md
@@ -63,7 +63,6 @@ article has plenty of links to related topics.
 
 ---
 We are continually working on creating new guides and improving existing ones so if you have feedback or would like to see a guide
-on a particular topic don't hesitate to get in touch via [support@Altis-dxp.com](mailto:support@altis-dxp.com) or by asking a
-question on the [Altis Dashboard](https://dashboard.altis-dxp.com/#/support/new/question).
+on a particular topic don't hesitate to get in touch via the [Altis Dashboard](support://new).
 
 <!-- markdownlint-disable-file MD025 -->


### PR DESCRIPTION
Replaces all mailto links in the documentation with support links.

Fixes https://github.com/humanmade/altis-documentation/issues/551