### PR TITLE
Adds v22 upgrade guide

### DIFF
--- a/other-docs/guides/updating-php/README.md
+++ b/other-docs/guides/updating-php/README.md
@@ -10,12 +10,12 @@ There are 2 key steps to getting ready for a new version of PHP:
 
 ## Altis Compatibility Chart
 
-| Altis | PHP 8.0        | PHP 8.1       | PHP 8.2        | PHP 8.3        |
-|-------|----------------|---------------|----------------|----------------|
-| v22   | **Deprecated** | **Supported** | **Supported**  | **Supported**  |
-| v21   | **Deprecated** | **Supported** | **Supported**  | *Experimental* |
-| v20   | **Deprecated** | **Supported** | **Supported**  | *Experimental* |
-| v19   | **Deprecated** | **Supported** | **Supported**  |                |
+| Altis | PHP 8.1       | PHP 8.2        | PHP 8.3        |
+|-------|---------------|----------------|----------------|
+| v22   | **Supported** | **Supported**  | **Supported**  |
+| v21   | **Supported** | **Supported**  | *Experimental* |
+| v20   | **Supported** | **Supported**  | *Experimental* |
+| v19   | **Supported** | **Supported**  |                |
 
 ## Checking PHP Version Compatibility
 

--- a/other-docs/guides/updating-php/README.md
+++ b/other-docs/guides/updating-php/README.md
@@ -12,10 +12,10 @@ There are 2 key steps to getting ready for a new version of PHP:
 
 | Altis | PHP 8.0        | PHP 8.1       | PHP 8.2        | PHP 8.3        |
 |-------|----------------|---------------|----------------|----------------|
-| v21   |                | **Supported** | **Supported**  | *Experimental* |
-| v20   |                | **Supported** | **Supported**  | *Experimental* |
-| v19   |                | **Supported** | **Supported**  |                |
-| v18   | **Deprecated** | **Supported** | **Supported**  |                |
+| v22   | **Deprecated** | **Supported** | **Supported**  | **Supported**  |
+| v21   | **Deprecated** | **Supported** | **Supported**  | *Experimental* |
+| v20   | **Deprecated** | **Supported** | **Supported**  | *Experimental* |
+| v19   | **Deprecated** | **Supported** | **Supported**  |                |
 
 ## Checking PHP Version Compatibility
 

--- a/other-docs/guides/upgrading/v22.md
+++ b/other-docs/guides/upgrading/v22.md
@@ -64,11 +64,11 @@ See the [WordPress 6.7 Field Guide](https://make.wordpress.org/core/2024/10/23/w
 
 #### New create-alias Command for WP-CLI
 
-Altis Local Server now includes a create-alias command, making it easier to use WP-CLI by generating an alias for the PHP Docker container. This allows users to run commands with a simpler syntax, such as `wp @local [command]`. This feature is especially useful for those with WP-CLI installed locally, enabling a more familiar and streamlined workflow with shorter commands and tab completion support.
+Altis Local Server now includes a create-alias command, making it easier to use WP-CLI by generating an alias for the PHP Docker container. This allows users to run commands with a simpler syntax, such as `wp @local [command]`. This feature is useful for those with WP-CLI installed locally, enabling a more familiar and streamlined workflow with shorter commands and tab completion support.
 
 #### **default-site-url** Override Option for WP-CLI
 
-Altis now allows setting a default site URL for WP-CLI commands, ensuring they operate on the correct site within a local environment. This is especially beneficial when the main site runs on a subpath rather than the root URL.
+Altis now allows setting a default site URL for WP-CLI commands, ensuring they operate on the correct site within a local environment. This is beneficial when the main site runs on a subpath rather than the root URL.
 
 By configuring this option, developers can avoid unintended operations on the wrong site and improve workflow efficiency.
 

--- a/other-docs/guides/upgrading/v22.md
+++ b/other-docs/guides/upgrading/v22.md
@@ -1,0 +1,84 @@
+---
+order: 22
+---
+
+# Upgrading to v22
+
+*If you are migrating from WordPress to Altis, check out the [migrating guide](../migrating/) first.*
+
+To upgrade to Altis v22, edit your `composer.json` and change the version constraint for `altis/altis` and any local environment
+modules to `^22.0.0`.
+
+```json
+{
+	"require": {
+		"altis/altis": "^22.0.0"
+	},
+	"require-dev": {
+		"altis/local-server": "^22.0.0"
+	},
+	"config": {
+		"platform": {
+			"php": "8.2"
+		}
+	}
+}
+```
+
+Once you have made these changes, run `composer update` and then run the `wp altis migrate` command:
+
+```sh
+# For cloud environments
+wp altis migrate
+
+# For local server
+composer server cli -- altis migrate
+```
+
+## PHP
+
+We now fully support PHP 8.3, allowing you to use it seamlessly in your projects. If you’d like to test your code locally, you can do so with [Local Server](docs://local-server/).
+
+Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date compatibility, testing and upgrading information.
+
+## Headline Features
+
+### WordPress 6.7.1
+
+WordPress 6.7.1 is a fast-follow maintenance release that addresses 16 bugs introduced in WordPress 6.7. This update focuses on improving stability across Core and the Block Editor.
+
+Key fixes include:
+- Resolving UI issues in the Customizer.
+- Fixing image handling in the Block Editor, including PNG-to-JPEG conversion and Safari uploads.
+- Enhancements to the Interactivity API, ensuring consistency between client and server states.
+- Improvements to translation handling and text domain loading.
+- Fixes for login page styling, image editing menu localization and more.
+
+This release ensures a smoother experience for both users and developers.
+
+You can review a summary of the maintenance updates in this release by reading the [WordPress 6.7.1 Release Candidate announcement](https://make.wordpress.org/core/2024/11/20/wordpress-6-7-1-rc1-is-now-available/).
+
+See the [WordPress 6.7 Field Guide](https://make.wordpress.org/core/2024/10/23/wordpress-6-7-field-guide/) for more information.
+
+### Altis Local Server Features
+
+#### New create-alias Command for WP-CLI
+
+Altis Local Server now includes a create-alias command, making it easier to use WP-CLI by generating an alias for the PHP Docker container. This allows users to run commands with a simpler syntax, such as `wp @local [command]`. This feature is especially useful for those with WP-CLI installed locally, enabling a more familiar and streamlined workflow with shorter commands and tab completion support.
+
+#### **default-site-url** Override Option for WP-CLI
+
+Altis now allows setting a default site URL for WP-CLI commands, ensuring they operate on the correct site within a local environment. This is especially beneficial when the main site runs on a subpath rather than the root URL.
+
+By configuring this option, developers can avoid unintended operations on the wrong site and improve workflow efficiency.
+
+For more details, refer to the [default site URL documentation](docs://local-server/cli/#default-site-url).
+
+### Altis Core improvements
+
+We have incorporated many updates to modules and libraries in Altis to bring in important bug fixes and improvements.
+
+### Documentation
+
+Our developer focused documentation has been improved again. As usual, feedback from our customers and partners is always welcome.
+Please [send us any feedback you have](support://new).


### PR DESCRIPTION
- Added upgrading guide for Altis v22
- Changed examples to use v22.
- Update PHP 8.3 to "supported" for v22
- Set PHP 8.0 to deprecated for all versions as it was announced as no longer supported in v19
- Delivers https://github.com/humanmade/product-dev/issues/1696