### PR TITLE
Altis v22 upgrade guide

### DIFF
--- a/other-docs/guides/upgrading/v22.md
+++ b/other-docs/guides/upgrading/v22.md
@@ -47,7 +47,7 @@ Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date com
 
 WordPress 6.7.2 is a maintenance release that addresses 35 bugs introduced in WordPress 6.7, improving stability across Core and the Block Editor. This release also includes a fix for the Twenty Twenty-Five theme, leading to an updated version of the theme being released.
 
-Key Fixes in This Release
+Key fixes include:
 - Fixes Customizer UI issues and accordion styles.
 - Improves block editor behavior and meta panel visibility.
 - Updates test automation and fixes pagination issues.

--- a/other-docs/guides/upgrading/v22.md
+++ b/other-docs/guides/upgrading/v22.md
@@ -43,23 +43,6 @@ Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date com
 
 ## Headline Features
 
-### WordPress 6.7.2
-
-WordPress 6.7.2 is a maintenance release that addresses 35 bugs introduced in WordPress 6.7, improving stability across Core and the Block Editor.
-
-Key fixes include:
-- Fixes Customizer UI issues and accordion styles.
-- Improves block editor behavior and meta panel visibility.
-- Updates test automation and fixes pagination issues.
-- Resolves HTML Processor and Interactivity API bugs.
-- Fixes Chrome mobile image display issues.
-
-This release ensures a smoother experience for both users and developers.
-
-You can review a summary of the maintenance updates in this release by reading the [WordPress 6.7.2 Release Candidate announcement](https://make.wordpress.org/core/2025/02/07/wordpress-6-7-2-rc2-is-now-available/).
-
-See the [WordPress 6.7 Field Guide](https://make.wordpress.org/core/2024/10/23/wordpress-6-7-field-guide/) for more information.
-
 ### Altis Local Server Features
 
 #### New create-alias Command for WP-CLI

--- a/other-docs/guides/upgrading/v22.md
+++ b/other-docs/guides/upgrading/v22.md
@@ -56,7 +56,7 @@ Key Fixes in This Release
 
 This release ensures a smoother experience for both users and developers.
 
-You can review a summary of the maintenance updates in this release by reading the [WordPress 6.7.2 Release Candidate announcement](https://make.wordpress.org/core/tag/6-7-2/).
+You can review a summary of the maintenance updates in this release by reading the [WordPress 6.7.2 Release Candidate announcement](https://make.wordpress.org/core/2025/02/07/wordpress-6-7-2-rc2-is-now-available/).
 
 See the [WordPress 6.7 Field Guide](https://make.wordpress.org/core/2024/10/23/wordpress-6-7-field-guide/) for more information.
 

--- a/other-docs/guides/upgrading/v22.md
+++ b/other-docs/guides/upgrading/v22.md
@@ -43,20 +43,20 @@ Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date com
 
 ## Headline Features
 
-### WordPress 6.7.1
+### WordPress 6.7.2
 
-WordPress 6.7.1 is a fast-follow maintenance release that addresses 16 bugs introduced in WordPress 6.7. This update focuses on improving stability across Core and the Block Editor.
+WordPress 6.7.2 is a maintenance release that addresses 35 bugs introduced in WordPress 6.7, improving stability across Core and the Block Editor. This release also includes a fix for the Twenty Twenty-Five theme, leading to an updated version of the theme being released.
 
-Key fixes include:
-- Resolving UI issues in the Customizer.
-- Fixing image handling in the Block Editor, including PNG-to-JPEG conversion and Safari uploads.
-- Enhancements to the Interactivity API, ensuring consistency between client and server states.
-- Improvements to translation handling and text domain loading.
-- Fixes for login page styling, image editing menu localization and more.
+Key Fixes in This Release
+- Fixes Customizer UI issues and accordion styles.
+- Improves block editor behavior and meta panel visibility.
+- Updates test automation and fixes pagination issues.
+- Resolves HTML Processor and Interactivity API bugs.
+- Fixes Chrome mobile image display issues.
 
 This release ensures a smoother experience for both users and developers.
 
-You can review a summary of the maintenance updates in this release by reading the [WordPress 6.7.1 Release Candidate announcement](https://make.wordpress.org/core/2024/11/20/wordpress-6-7-1-rc1-is-now-available/).
+You can review a summary of the maintenance updates in this release by reading the [WordPress 6.7.2 Release Candidate announcement](https://make.wordpress.org/core/tag/6-7-2/).
 
 See the [WordPress 6.7 Field Guide](https://make.wordpress.org/core/2024/10/23/wordpress-6-7-field-guide/) for more information.
 

--- a/other-docs/guides/upgrading/v22.md
+++ b/other-docs/guides/upgrading/v22.md
@@ -45,7 +45,7 @@ Refer to our [PHP Version Guide](docs://guides/updating-php/) for up-to-date com
 
 ### WordPress 6.7.2
 
-WordPress 6.7.2 is a maintenance release that addresses 35 bugs introduced in WordPress 6.7, improving stability across Core and the Block Editor. This release also includes a fix for the Twenty Twenty-Five theme, leading to an updated version of the theme being released.
+WordPress 6.7.2 is a maintenance release that addresses 35 bugs introduced in WordPress 6.7, improving stability across Core and the Block Editor.
 
 Key fixes include:
 - Fixes Customizer UI issues and accordion styles.


### PR DESCRIPTION
- Add WordPress 6.7.2 Release to the upgrade guide.