### PR TITLE
Update the minimum PHP version to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		]
 	},
 	"require": {
-		"php": ">=7.1",
+		"php": ">=8.2",
 		"erusev/parsedown": "~1.7.4",
 		"mustangostang/spyc": "^0.6.3"
 	},


### PR DESCRIPTION
Update the minimum PHP version to that which Altis supports. This will allow dependabot to run successfully.

Addresses: humanmade/product-dev#1735