### PR TITLE
Fix warning when no metadata is set for title

### DIFF
--- a/inc/class-page.php
+++ b/inc/class-page.php
@@ -118,7 +118,7 @@ class Page {
 			$order_b = $b->get_meta( 'order' ) ?? 0;
 
 			if ( $order_a === $order_b ) {
-				return strnatcasecmp( $a->get_meta( 'title' ), $b->get_meta( 'title' ) );
+				return strnatcasecmp( $a->get_meta( 'title' ) ?? '', $b->get_meta( 'title' ) ?? '' );
 			}
 
 			return $order_a <=> $order_b;


### PR DESCRIPTION
This stops the PHP warnings:

````
PHP Warning:  strnatcasecmp(): Argument #1 ($string1) is not a string in /path/to/your/plugin/inc/class-page.php on line 121
PHP Deprecated:  strnatcasecmp(): Passing null to parameter #1 ($string1) of type string is deprecated in /usr/src/app/packages/documentation/inc/class-page.php on line 121
PHP Deprecated:  strnatcasecmp(): Passing null to parameter #2 ($string2) of type string is deprecated in /usr/src/app/packages/documentation/inc/class-page.php on line 121
```

Fixes: https://github.com/humanmade/altis-documentation/issues/616