### PR TITLE
Fix some minor changes from v23 branch

### DIFF
--- a/other-docs/guides/upgrading/README.md
+++ b/other-docs/guides/upgrading/README.md
@@ -18,10 +18,10 @@ your `composer.json`. For example, to upgrade to Altis version 21.
 {
     "name": "company-name/my-site",
     "require": {
-        "altis/altis": "^21.0.0"
+        "altis/altis": "^23.0.0"
     },
     "require-dev": {
-        "altis/local-server": "^21.0.0"
+        "altis/local-server": "^23.0.0"
     }
 }
 ```
@@ -43,6 +43,8 @@ with "BREAKING: " in the version release notes.
 
 ## Upgrade Guides
 
+- [Version 23](./v23.md)
+- [Version 22](./v22.md)
 - [Version 21](./v21.md)
 - [Version 20](./v20.md)
 - [Version 19](./v19.md)

--- a/other-docs/guides/upgrading/v23.md
+++ b/other-docs/guides/upgrading/v23.md
@@ -11,17 +11,17 @@ modules to `^23.0.0`.
 
 ```json
 {
-	"require": {
-		"altis/altis": "^23.0.0"
-	},
-	"require-dev": {
-		"altis/local-server": "^23.0.0"
-	},
-	"config": {
-		"platform": {
-			"php": "8.2"
-		}
-	}
+    "require": {
+        "altis/altis": "^23.0.0"
+    },
+    "require-dev": {
+        "altis/local-server": "^23.0.0"
+    },
+    "config": {
+        "platform": {
+            "php": "8.2"
+        }
+    }
 }
 ```
 
@@ -39,11 +39,14 @@ composer server cli -- altis migrate
 
 Altis adds support to WordPress 6.8, "Cecil", which brings significant improvements to performance, security, and usability:
 
-- **Security**: `bcrypt` is now used for password hashing, replacing phpass. Application keys use stronger BLAKE2b hashing. Admins are alerted if open registration is active with high default roles.
+- **Security**: `bcrypt` is now used for password hashing, replacing phpass. Application keys use stronger BLAKE2b hashing. Admins
+  are alerted if open registration is active with high default roles.
 
-- **Performance**: Improved caching in WP_Query, better lazy loading, and speculative loading via the new Speculation Rules API for faster navigation.
+- **Performance**: Improved caching in WP_Query, better lazy loading, and speculative loading via the new Speculation Rules API for
+  faster navigation.
 
-- **Editor Enhancements**: Updated Style Book UI, new Query Loop options (date filters, exclude sticky posts), and persistent rendering mode for editing experience.
+- **Editor Enhancements**: Updated Style Book UI, new Query Loop options (date filters, exclude sticky posts), and persistent
+  rendering mode for editing experience.
 
 - **Accessibility**: Over 100 fixes across the admin and editor, including standardized tooltips and clearer admin notice prefixes.
 
@@ -53,21 +56,28 @@ For more details check the [WordPress 6.8 Field Guide](https://make.wordpress.or
 
 ### Altis Advanced Security, powered by Patchstack
 
-We're excited to launch Altis Advanced Security, a new additional add-on that provides real-time vulnerability protection for your Altis projects. Powered by Patchstack, this integration brings industry-leading virtual patching (vPatching) directly into your Altis environments.
+We're excited to launch Altis Advanced Security, a new additional add-on that provides real-time vulnerability protection for your
+Altis projects. Powered by Patchstack, this integration brings industry-leading virtual patching (vPatching) directly into your
+Altis environments.
 
 #### Why It Matters
 
-Identifying vulnerabilities is only the first step—mitigating them quickly is crucial. In many organizations, updating plugins or themes can take days or even weeks, leaving your sites exposed in the meantime.
+Identifying vulnerabilities is only the first step—mitigating them quickly is crucial. In many organizations, updating plugins or
+themes can take days or even weeks, leaving your sites exposed in the meantime.
 
 Even more critically, some plugins never release a fix, requiring manual workarounds or firewall rules.
 
-Altis Advanced Security solves this by automatically applying vPatches—plugin-level firewall rules that neutralize known vulnerabilities before an official fix is available. These rules are applied immediately and directly within WordPress, providing fast and targeted protection with minimal performance impact.
+Altis Advanced Security solves this by automatically applying vPatches—plugin-level firewall rules that neutralize known
+vulnerabilities before an official fix is available. These rules are applied immediately and directly within WordPress, providing
+fast and targeted protection with minimal performance impact.
 
 #### Key Features
 
-- **Real-Time Vulnerability Mitigation**: Instantly protects against known threats, without waiting for full plugin updates or release cycles.
+- **Real-Time Vulnerability Mitigation**: Instantly protects against known threats, without waiting for full plugin updates or
+  release cycles.
 
-- **Smart vPatching**: Only patches vulnerabilities in plugins you actually have installed, reducing overhead and improving efficiency.
+- **Smart vPatching**: Only patches vulnerabilities in plugins you actually have installed, reducing overhead and improving
+  efficiency.
 
 - **Seamless Integration**: Works alongside Altis's built-in CDN-level WAF to provide protection across Layers 3, 4, and 7.
 
@@ -75,29 +85,38 @@ Altis Advanced Security solves this by automatically applying vPatches—plugin-
 
 #### What's Next
 
-We’re actively working to expand Altis Advanced Security with new features, including automated anti-virus scanning for uploaded assets.
+We’re actively working to expand Altis Advanced Security with new features, including automated anti-virus scanning for uploaded
+assets.
 
-Altis Advanced Security is available as a paid add-on, billed per site. For pricing and enablement, please contact your Account Manager.
+Altis Advanced Security is available as a paid add-on, billed per site. For pricing and enablement, please contact your Account
+Manager.
 
 ### Altis Local Server Features
 
 This release includes several bug fixes and introduces new capabilities to enhance development workflows. New in this release:
 
-#### Extensible Docker-Compose Configuration Support 
+#### Extensible Docker-Compose Configuration Support
 
-Altis Local Server now includes an extensible mechanism to allow for package-specific customizations of the `docker-compose` configuration. It enables developers to define additional configurations via Composer packages and have them incorporated into the `docker-compose.yml` generation process. 
+Altis Local Server now includes an extensible mechanism to allow for package-specific customizations of the `docker-compose`
+configuration. It enables developers to define additional configurations via Composer packages and have them incorporated into the
+`docker-compose.yml` generation process.
 
 ### Altis Dashboard Features
 
-In order to empower and improve developer experience we continue to ship self-service features and improvements to the Dashboard. In this release we are introducing a much expected feature, the ability to self-service PHP upgrades on your environments.
+In order to empower and improve developer experience we continue to ship self-service features and improvements to the Dashboard. In
+this release we are introducing a much expected feature, the ability to self-service PHP upgrades on your environments.
 
 #### Self-Service PHP Upgrades
 
-We’re introducing Self-service PHP upgrades, empowering users to upgrade their PHP version independently and instantly via the Altis Dashboard—no support request needed.
+We’re introducing Self-service PHP upgrades, empowering users to upgrade their PHP version independently and instantly via the Altis
+Dashboard—no support request needed.
 
-Previously, PHP upgrades required contacting support and waiting for manual updates via infrastructure changes—adding delays, uncertainty, and deployment risks. Now, users can trigger PHP upgrades on their own schedule, reducing turnaround time and improving deployment predictability.
+Previously, PHP upgrades required contacting support and waiting for manual updates via infrastructure changes—adding delays,
+uncertainty, and deployment risks. Now, users can trigger PHP upgrades on their own schedule, reducing turnaround time and improving
+deployment predictability.
 
-This update builds on our ongoing mission to give developers greater control over their infrastructure, just like with Composer-managed WordPress versions. We're continuing to explore ways to further streamline your development experience.
+This update builds on our ongoing mission to give developers greater control over their infrastructure, just like with
+Composer-managed WordPress versions. We're continuing to explore ways to further streamline your development experience.
 
 ### Altis Core improvements
 


### PR DESCRIPTION
Fixes the markdown formatting.
Added missing links for recent upgrade guides.
Uses latest v.23 upgrade example.