### PR TITLE
Add a link to the documentation for Extensible Docker Containers

### DIFF
--- a/other-docs/guides/upgrading/v23.md
+++ b/other-docs/guides/upgrading/v23.md
@@ -97,9 +97,9 @@ This release includes several bug fixes and introduces new capabilities to enhan
 
 #### Extensible Docker-Compose Configuration Support
 
-Altis Local Server now includes an extensible mechanism to allow for package-specific customizations of the `docker-compose`
-configuration. It enables developers to define additional configurations via Composer packages and have them incorporated into the
-`docker-compose.yml` generation process.
+Altis Local Server now includes an [extensible mechanism](docs://local-server/extra-containers.md) to allow for package-specific
+customizations of the `docker-compose` configuration. It enables developers to define additional configurations via Composer
+packages and have them incorporated into the `docker-compose.yml` generation process.
 
 ### Altis Dashboard Features
 


### PR DESCRIPTION

Add a link to the documentation for Extensible Docker Compose configuration support.


https://github.com/user-attachments/assets/e23e7261-2581-41bf-8257-9a37a8e925e9



