### PR TITLE
Remove a second H1 on the build size page

### DIFF
--- a/other-docs/faq/Common-Errors-and-Issues/build-size.md
+++ b/other-docs/faq/Common-Errors-and-Issues/build-size.md
@@ -22,8 +22,8 @@ It can also be the case that your Node modules directory has inflated the build 
 
 To remove your Node modules directory via your build-script, you can add something like:
 
-# Clean up node_modules to reduce the size of the build
 ```
+# Clean up node_modules to reduce the size of the build
 find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +
 ```
 


### PR DESCRIPTION
This removes a second H1 tag from the page caused by the shell comment being outside the code markup.

Live page:
<img width="800" height="980" alt="CleanShot 2025-07-21 at 10 05 20" src="https://github.com/user-attachments/assets/052879f2-d81f-434f-8f2e-add8775c0839" />

Local before the fix:
<img width="800" height="510" alt="CleanShot 2025-07-21 at 10 06 50" src="https://github.com/user-attachments/assets/0f073cf8-f23e-4935-ba23-0e8e26741dae" />

Local after the fix:
<img width="800" height="510" alt="CleanShot 2025-07-21 at 10 07 02" src="https://github.com/user-attachments/assets/d2852d9a-d58a-43a0-995f-421cfcb4094f" />
