### PR TITLE
Move FAQs to the end of the list

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -137,10 +137,6 @@ function filter_add_dev_docs_set( array $sets ) : array {
 	add_docs_for_group( $guides, $other_docs . '/guides' );
 	$dev_set->add_group( 'guides', $guides );
 
-	$faq = new Group( __( 'FAQ', 'altis' ) );
-	add_docs_for_group( $faq, $other_docs . '/faq' );
-	$dev_set->add_group( 'faq', $faq );
-
 	// Add all the registered modules.
 	$modules = Module::get_all();
 	uasort( $modules, function ( Module $a, Module $b ) : int {
@@ -155,6 +151,11 @@ function filter_add_dev_docs_set( array $sets ) : array {
 
 		$dev_set->add_group( $id, $module_docs );
 	}
+
+	// Add the FAQs at the end.
+	$faq = new Group( __( 'FAQ', 'altis' ) );
+	add_docs_for_group( $faq, $other_docs . '/faq' );
+	$dev_set->add_group( 'faq', $faq );
 
 	$sets[ DEV_DOCS_SET_ID ] = $dev_set;
 

--- a/other-docs/faq/README.md
+++ b/other-docs/faq/README.md
@@ -1,5 +1,6 @@
 ---
 title: FAQ
+order: 90
 ---
 
 # Frequently Asked Questions


### PR DESCRIPTION
This change moved the FAQs section to the end of the list.

Resolves https://github.com/humanmade/altis-documentation/issues/614

<img width="549" height="1170" alt="CleanShot 2025-07-24 at 17 36 40" src="https://github.com/user-attachments/assets/6c7eb8aa-ee7b-414b-807f-84efcfcff8b5" />
