### PR TITLE
Fix missing v24 upgrade link

### DIFF
--- a/other-docs/guides/upgrading/README.md
+++ b/other-docs/guides/upgrading/README.md
@@ -18,10 +18,10 @@ your `composer.json`. For example, to upgrade to Altis version 21.
 {
     "name": "company-name/my-site",
     "require": {
-        "altis/altis": "^23.0.0"
+        "altis/altis": "^24.0.0"
     },
     "require-dev": {
-        "altis/local-server": "^23.0.0"
+        "altis/local-server": "^24.0.0"
     }
 }
 ```
@@ -43,6 +43,7 @@ with "BREAKING: " in the version release notes.
 
 ## Upgrade Guides
 
+- [Version 24](./v24.md)
 - [Version 23](./v23.md)
 - [Version 22](./v22.md)
 - [Version 21](./v21.md)


### PR DESCRIPTION
Adds the missing link to the v24 upgrade guide.
