### PR TITLE
Specify the required page order in the front matter.

### DIFF
--- a/other-docs/getting-started/README.md
+++ b/other-docs/getting-started/README.md
@@ -1,3 +1,6 @@
+---
+order: -100
+---
 # Getting Started
 
 ![Getting started banner](./assets/banner-getting-started.png)

--- a/other-docs/guides/README.md
+++ b/other-docs/guides/README.md
@@ -1,3 +1,7 @@
+---
+order: -90
+---
+
 # Guides
 
 ![Guides banner](./assets/banner-guides.png)

--- a/other-docs/welcome.md
+++ b/other-docs/welcome.md
@@ -1,3 +1,8 @@
+---
+## This page should come first
+order: -999
+---
+
 # Welcome
 
 ![Welcome banner](./assets/banner-welcome.png)


### PR DESCRIPTION
The required page order for these special pages should be specified using the normal order mechanism our documentation system supports.

Fixes https://github.com/humanmade/altis-documentation/issues/668

