### PR TITLE
Fix welcome.md internal links to use docs://

### DIFF
--- a/other-docs/welcome.md
+++ b/other-docs/welcome.md
@@ -29,22 +29,22 @@ What this means for you:
 
 ## Getting Started
 
-The [Getting Started documentation](getting-started/) walks you through your first Altis project. This
-includes [project setup](getting-started/), [configuring your project](getting-started/configuration.md),
+The [Getting Started documentation](docs://getting-started/) walks you through your first Altis project. This
+includes [project setup](docs://getting-started/), [configuring your project](docs://getting-started/configuration.md),
 and [building your own modules](docs://core/custom-modules.md).
 
 ## Guides
 
-A [series of Guides](guides/) is provided to guide you through specific tasks or types of projects. These guides walk you
+A [series of Guides](docs://guides/) is provided to guide you through specific tasks or types of projects. These guides walk you
 through the steps to achieve tasks.
 
 ## Upgrading
 
 If you are upgrading from one version of Altis to another make sure to thoroughly read and follow the steps
-in [the upgrading guides](guides/upgrading/).
+in [the upgrading guides](docs://guides/upgrading/).
 
 ## Releases
 
 There is a [list of current and previous releases here](https://docs.altis-dxp.com/releases/), as well as more information
-on [the Altis release process](guides/altis-releases.md) and the
-accompanying [long term support policy](guides/long-term-support.md) in our guides.
+on [the Altis release process](docs://guides/altis-releases.md) and the
+accompanying [long term support policy](docs://guides/long-term-support.md) in our guides.


### PR DESCRIPTION
Update relative links to documentation pages to use the docs:// protocol for consistency with the documentation system.

- Fixes https://github.com/humanmade/product-dev/issues/1961