### PR TITLE
Update user docs to replace reusable blocks with synced patterns

### DIFF
--- a/other-docs/guides/migrating/README.md
+++ b/other-docs/guides/migrating/README.md
@@ -71,7 +71,6 @@ them.
 
 Currently, Altis bundles the following plugins:
 
-- `altis-reusable-blocks`
 - `asset-loader`
 - `aws-analytics`
 - `aws-rekognition`

--- a/user-docs/README.md
+++ b/user-docs/README.md
@@ -25,7 +25,7 @@ article has plenty of links to related topics.
 
 - [Content Creation](content-and-content-blocks/README.md)
 - [Creating Content with Blocks](content-and-content-blocks/creating-content-with-blocks.md)
-- [Reusable Blocks](content-and-content-blocks/reusable-blocks.md)
+- [Synced Patterns](content-and-content-blocks/reusable-blocks.md)
 
 ### Collaboration & users
 

--- a/user-docs/collaboration-and-users/managing-roles.md
+++ b/user-docs/collaboration-and-users/managing-roles.md
@@ -51,7 +51,7 @@ managing content and writers, rather than making technical changes.
 ### Author
 
 Authors have permission to publish and manage their own posts, including deleting their own posts they’ve previously published. They
-can upload media and create reusable blocks, including editing and deleting their own blocks. Authors can also choose existing
+can upload media and create synced patterns, including editing and deleting their own patterns. Authors can also choose existing
 categories and add their own tags.
 
 ### Contributor

--- a/user-docs/collaboration-and-users/roles-and-permissions.md
+++ b/user-docs/collaboration-and-users/roles-and-permissions.md
@@ -32,14 +32,14 @@ your site owner when deciding who to assign as Administrator.
 Editors can publish and manage their own and other users’ posts and pages. They
 can also moderate comments and manage categories and links. This role is
 primarily focused on content, so can’t make changes or updates to themes or
-plugins. Editors can also create and edit reusable blocks, but they can’t delete
+plugins. Editors can also create and edit synced patterns, but they can’t delete
 them.
 
 ### Author
 
 Authors can create, publish and delete their own posts. This includes uploading
-media files and creating reusable blocks–and editing and deleting reusable
-blocks they’ve created. This role can also add existing categories and tags.
+media files and creating synced patterns–and editing and deleting synced
+patterns they’ve created. This role can also add existing categories and tags.
 Authors can also view comments (including pending) but can’t moderate, publish
 or remove them.
 

--- a/user-docs/content-and-content-blocks/README.md
+++ b/user-docs/content-and-content-blocks/README.md
@@ -234,7 +234,7 @@ These icons mean (left-to-right):
   - **Insert** a new block **after** the block
   - **Move** block to another section
   - Edit block as **HTML**
-  - **Add** block to [Reusable blocks](reusable-blocks.md)
+  - **Create pattern** (synced) from block — see [Synced Patterns](reusable-blocks.md)
   - **Group** block
   - **Remove** block
 

--- a/user-docs/content-and-content-blocks/creating-content-with-blocks.md
+++ b/user-docs/content-and-content-blocks/creating-content-with-blocks.md
@@ -262,7 +262,7 @@ Maybe you find yourself often creating a layout with the same blocks. For exampl
 
 ![Screenshot](../assets/creating-with-blocks-image19.png)
 
-You can save this as a template that can be reused. View [Reusable blocks](reusable-blocks.md) to see how.
+You can save this as a synced pattern that can be reused. View [Synced Patterns](reusable-blocks.md) to see how.
 
 #### How to edit multiple blocks of the same type
 

--- a/user-docs/content-and-content-blocks/reusable-blocks.md
+++ b/user-docs/content-and-content-blocks/reusable-blocks.md
@@ -2,200 +2,90 @@
 order: 30
 ---
 
-# Reusable Blocks
+# Synced Patterns
 
 Ever found yourself creating the same content block **over and over**? All that repetition wastes time, is inefficient, and can lead
-to mistakes. It’s also totally unnecessary. That’s because you can create Reusable Blocks instead. Create a block once, then reuse
+to mistakes. It's also totally unnecessary. That's because you can create Synced Patterns (formerly known as Reusable Blocks) instead. Create a pattern once, then reuse
 across **posts**, **pages**–even different **websites**.
 
-You’ll save loads of time. For example, imagine all your blog posts end with a “contact us” block. You include an email address,
-phone number, maybe an office location. If any of those details change, simply edit the Reusable Block once. Rather than editing all
+You'll save loads of time. For example, imagine all your blog posts end with a "contact us" block. You include an email address,
+phone number, maybe an office location. If any of those details change, simply edit the Synced Pattern once. Rather than editing all
 your posts one by one.
 
-## How to create a Reusable Block
+Synced patterns can be managed via **Appearance > Editor > Patterns** in the admin, or directly from the block inserter's **Synced** tab.
 
-This option is for when you’re in the page or post editor.
+## How to create a Synced Pattern
+
+This option is for when you're in the page or post editor.
 
 Choose or create the [block](creating-content-with-blocks.md) you want to make reusable.
 
-Click the **three dots > Add to Reusable Blocks**:
+Click the **three dots > Create pattern**:
 
-![Screenshot](../assets/reusable-blocks-image20.png)
+Give the pattern a descriptive name for you and/or your team, and ensure the **Synced** toggle is enabled.
 
-This opens a dialogue box for you to enter a name. Give the Reusable Block a descriptive name for you and/or your team:
+Click **Save**. The next time you add a block, the synced pattern will appear in the block inserter.
 
-![Screenshot](../assets/reusable-blocks-image9.png)
+## How to add a Synced Pattern to your page/post
 
-Click **Save**. The name now appears above your newly created Reusable Block:
+Adding a Synced Pattern works the same way as adding any other block. Click the + sign to open the block inserter, then browse the
+**Synced** tab or use the search bar to find the pattern by name.
 
-![Screenshot](../assets/reusable-blocks-image14.png)
+### A shortcut to adding a Synced Pattern
 
-The next time you add a block, the Reusable block will appear in your search results:
+You can search for a synced pattern by name just like other blocks.
 
-![Screenshot](../assets/reusable-blocks-image21.png)
+Enter / and then your pattern's name. As you type after **/**, Altis will start suggesting
+blocks for you.
 
-## How to add a Reusable Block to your page/post
+## How to edit a Synced Pattern
 
-Adding a Reusable Block works the same way as adding any other block. Click the + sign to view the options:
+The changes you make will show wherever you're using the Synced Pattern. However, sometimes you might only want to **edit the
+pattern on one page or post**.
 
-![Screenshot](../assets/reusable-blocks-image25.png)
+That's when you can **Detach** the pattern to turn it into regular blocks.
 
-You can either enter the Reusable Block’s name into the search bar:
+### How to detach a Synced Pattern to regular blocks
 
-![Screenshot](../assets/reusable-blocks-image6.png)
+Select the Synced Pattern you want to detach. Then click the **three dots > Detach** option.
 
-Or you can click **Reusable Block** and then click on your preferred block:
+## How to group blocks into a Synced Pattern
 
-![Screenshot](../assets/reusable-blocks-image7.png)
-
-### A shortcut to adding a Reusable Block
-
-You can search for a reusable block by name just like other blocks.
-
-Enter / and then your Reusable Block’s name. For example: **/contact us**. As you type after **/**, Altis will start suggesting
-blocks for you:
-
-![Screenshot](../assets/reusable-blocks-image3.png)
-
-## How to edit a Reusable Block
-
-The changes you make will show wherever you’re using the Reusable Block. However, sometimes you might only want to **edit the
-Reusable Block on one page or post**.
-
-That’s when you can **Convert** to regular blocks.
-
-### How to convert a Reusable Block to a regular block
-
-Select the Reusable Block you want to convert. Then click the Convert icon:
-
-![Screenshot](../assets/reusable-blocks-image15.png)
-
-## How to group Reusable Blocks
-
-A Reusable Block can also be a group of blocks. For example, imagine you want to create a **template** for journalists to use when
-publishing news articles. In the example below, you’ve created four blocks:
+A Synced Pattern can also be a group of blocks. For example, imagine you want to create a **template** for journalists to use when
+publishing news articles. In the example below, you've created four blocks:
 
 1. Heading
 2. Introduction
 3. Image
 4. Article
 
-![Screenshot](../assets/reusable-blocks-image12.png)
+Select the blocks at once. You can click and drag to highlight, or hold Shift + click.
 
-Select the four blocks at once. You can click and drag to highlight, or hold Shift + click:
+Click **Options** (three dots) when it appears at the top of your first highlighted block. Then click **Create pattern** and enable the **Synced** toggle.
 
-![Screenshot](../assets/reusable-blocks-image2.png)
+## How to export/import Synced Patterns
 
-Click **Options** (three dots) when it appears at the top of your first highlighted block. Then click **Add to Reusable Blocks**:
-
-![Screenshot](../assets/reusable-blocks-image19.png)
-
-## How to export/import Reusable Blocks
-
-Reusable Blocks are happy to travel – you can take them anywhere. **Insert** into pages and posts, **import** and **export** across
+Synced Patterns are happy to travel – you can take them anywhere. **Insert** into pages and posts, **import** and **export** across
 different WordPress websites. You can also **download** them as backups.
 
-### How to export Reusable Blocks
+### How to export Synced Patterns
 
-Head to your list of Reusable Blocks:
+Head to **Appearance > Editor > Patterns** and browse to your synced patterns.
 
-![Screenshot](../assets/reusable-blocks-image4.png)
-
-Hover over the Reusable Block you want to export, and click **Export as JSON**. JSON (JavaScript Objection Notation) is a common way
+From the pattern's options menu, choose **Export as JSON**. JSON (JavaScript Object Notation) is a common way
 to transport data, nice and easy.
-
-![Screenshot](../assets/reusable-blocks-image13.png)
 
 This automatically downloads to your device.
 
-### How to import Reusable Blocks
+### How to import Synced Patterns
 
-Open **Reusable Blocks** in your dashboard:
+Open **Appearance > Editor > Patterns** in your dashboard.
 
-![Screenshot](../assets/reusable-blocks-image4.png)
+Use the import option to upload a JSON file containing the pattern.
 
-Click **Import from JSON**:
+### How to manage duplicate Synced Pattern names
 
-![Screenshot](../assets/reusable-blocks-image22.png)
+Here's one thing to remember. If you **already have a Synced Pattern with the same name** in your list, you'll end up with two
+patterns with the same name. It will not overwrite the previous one.
 
-Choose the file and click **Import**:
-
-![Screenshot](../assets/reusable-blocks-image26.png)
-
-### How to manage duplicate Reusable Block names
-
-Here’s one thing to remember. If you **already have a Reusable Block with the same name** in your list, you’ll end up with two
-blocks with the same name. It will not overwrite the previous one:
-
-![Screenshot](../assets/reusable-blocks-image1.png)
-To avoid any “Er, which Reusable Block is the right one?” headaches, just **edit the name** after importing. Check under **Date** to
-see which one you just imported.
-
-![Screenshot](../assets/reusable-blocks-image10.png)
-
-Then **hover** and click **Edit** on the Reusable Block:
-
-![Screenshot](../assets/reusable-blocks-image8.png)
-
-## How to add a block category
-
-With this option, you can add more details to your categories:
-
-Click **Reusable Blocks > Categories**:
-
-![Screenshot](../assets/reusable-blocks-image5.png)
-
-You’ll see the option to add a new category:
-
-![Screenshot](../assets/reusable-blocks-image24.png)
-
-- **Name**
-  Try to keep this as short as possible. Ideally, a descriptive word or phrase that tells people what the category is about.
-- **Slug**
-  This is not used.
-- **Parent**
-  You can create your categories in a hierarchy and choose a parent category here. For example, categories of Football and Tennis
-  could have Sport as a category parent.
-- **Description**
-  This does not appear anywhere on the site and is only for your reference.
-
-### Editing a Reusable Block category
-
-Click **Reusable Blocks > Categories**:
-
-![Screenshot](../assets/reusable-blocks-image17.png)
-
-You’ll see the list of categories, **Bulk edit** options, plus a **Search bar** at the top. The **Count** column shows how often the
-category is being used:
-
-![Screenshot](../assets/reusable-blocks-image23.png)
-
-**Hover** over the category you want to edit:
-
-![Screenshot](../assets/reusable-blocks-image27.png)
-
-You’ll see two editing options:
-
-- **Quick edit**
-  Edit the category name and slug
-- **Edit**
-  Edit the category name, slug, parent and description
-
-### Deleting a Reusable Block category
-
-Hover over the category and click **Delete > OK**:
-
-![Screenshot](../assets/reusable-blocks-image16.png)
-
-To **delete more than one Reusable Block**, click the square at the top to select all categories, Deselect any you want to keep, and
-choose **Delete** from the Bulk action dropdown:
-
-![Screenshot](../assets/reusable-blocks-image18.png)
-
-## How to see where your Reusable Blocks are being used
-
-When you edit a reusable Block, the edit screen shows everywhere the Reusable Block is used.
-
-Open the Reusable Block, and click the **Relationships** icon:
-
-![Screenshot](../assets/reusable-blocks-image28.png)
+To avoid any confusion, just **edit the name** after importing.


### PR DESCRIPTION
Update terminology and remove references to Altis-specific reusable blocks features (categories, usage tracking, relationships) that are no longer available after removing the altis-reusable-blocks module.

See https://github.com/humanmade/product-dev/issues/2046