### PR TITLE
Update compatibility chart for Altis v26

### DIFF
--- a/other-docs/guides/updating-php/README.md
+++ b/other-docs/guides/updating-php/README.md
@@ -12,10 +12,10 @@ There are 2 key steps to getting ready for a new version of PHP:
 
 | Altis | PHP 8.4       | PHP 8.3        | PHP 8.2       | PHP 8.1       |
 |-------|---------------|----------------|---------------|---------------|
+| v26   | **Supported** | **Supported**  | *Deprecated*  | *Deprecated*  |
 | v25   | **Supported** | **Supported**  | *Deprecated*  | *Deprecated*  |
 | v24   |               | **Supported**  | **Supported** | *Deprecated*  |
 | v23   |               | **Supported**  | **Supported** | *Deprecated*  |
-| v22   |               | **Supported**  | **Supported** | **Supported** |
 
 ## Checking PHP Version Compatibility
 


### PR DESCRIPTION
- Adds Altis v26 to and removes Altis v22 from the compatibility chart
- Fixes https://github.com/humanmade/altis-documentation/issues/713