### PR TITLE
Document multisite registration flow change in v26 upgrade guide

### DIFF
--- a/other-docs/guides/upgrading/v26.md
+++ b/other-docs/guides/upgrading/v26.md
@@ -69,6 +69,23 @@ For more details check the [WordPress 6.9 Field Guide](https://make.wordpress.or
   were using this feature, you can add the 10Up plugin [ElasticPress Labs](https://github.com/10up/ElasticPressLabs) to 
   re-enable user indexing.
 
+### Multisite registration flow change
+
+To remove plaintext passwords from the multisite sign-up process, account activation now redirects the user to the password reset
+page on `wp-login.php`, and welcome emails no longer include the generated password. Previously, `wp-activate.php` displayed the
+new password on screen and embedded it in the welcome email.
+
+If you rely on the previous behaviour — for example, if your sign-up experience depends on the registering user being returned to
+the front end of the site after activation — you can remove the filters that enable the new flow:
+
+```php
+remove_action( 'wpmu_activate_user', 'Altis\\CMS\\Signup_Notification\\redirect_to_password_reset', 20 );
+remove_action( 'wpmu_activate_blog', 'Altis\\CMS\\Signup_Notification\\redirect_blog_user_to_password_reset', 20 );
+```
+
+Hook these `remove_action()` calls on `init` at a priority later than `9` (for example, `add_action( 'init', $callback, 20 )`) so
+they run after the Altis CMS module has registered its own actions.
+
 ### Altis Core improvements
 
 We have incorporated many updates to modules and libraries in Altis to bring in important bug fixes and improvements.


### PR DESCRIPTION
## Summary
- Adds a "Multisite registration flow change" subsection to the v26 upgrade guide covering the new post-activation redirect to the password reset page and the removal of plaintext passwords from welcome emails.
- Includes the two `remove_action()` calls needed to restore the previous behaviour for sites that depend on the registering user being returned to the front end after activation.

Follow-up documentation for humanmade/altis-cms#922.
Addresses https://github.com/humanmade/product-dev/issues/2009

## Test plan
- [ ] Render `other-docs/guides/upgrading/v26.md` and confirm the new subsection reads correctly and the code block renders as PHP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)