### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - 'v*-branch'
+  pull_request:
+    branches:
+      - master
+      - main
+      - 'v*-branch'
+
+jobs:
+  ci:
+    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@master
+    with:
+      altis-package: altis/documentation
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/other-docs/guides/upgrading/v3.md
+++ b/other-docs/guides/upgrading/v3.md
@@ -119,8 +119,9 @@ your editor.
 
 In addition X-Ray data and the flame graph are now available as panels in Query Monitor.
 
-A [default Travis CI config](docs://dev-tools/continuous-integration.md) will be created if one does not already exist that will run
-the zero config PHPUnit tests.
+A [default CI config](docs://dev-tools/continuous-integration.md) will be created if one does not already exist that will run
+the zero config PHPUnit tests. (At the time of v3 this was a Travis configuration; in current Altis versions GitHub Actions is
+the default — see the linked Continuous Integration guide for the current setup.)
 
 ### Local Environment improvements (Local Chassis & Local Server modules)
 

--- a/other-docs/guides/upgrading/v3.md
+++ b/other-docs/guides/upgrading/v3.md
@@ -119,9 +119,8 @@ your editor.
 
 In addition X-Ray data and the flame graph are now available as panels in Query Monitor.
 
-A [default CI config](docs://dev-tools/continuous-integration.md) will be created if one does not already exist that will run
-the zero config PHPUnit tests. (At the time of v3 this was a Travis configuration; in current Altis versions GitHub Actions is
-the default — see the linked Continuous Integration guide for the current setup.)
+A [default Travis CI config](docs://dev-tools/continuous-integration.md) will be created if one does not already exist that will run
+the zero config PHPUnit tests.
 
 ### Local Environment improvements (Local Chassis & Local Server modules)
 


### PR DESCRIPTION
## Summary

Replaces `.travis.yml` with a thin caller for the reusable Module CI workflow at `humanmade/altis-dev-tools/.github/workflows/module-ci.yml`. The Travis file is left in place for the side-by-side migration window — remove in a follow-up once GHA is consistently green.

## Dependency

Requires the companion PR in `humanmade/altis-dev-tools` to merge first (adds the reusable workflow). Until that lands, this workflow will fail to load.

- Addresses: https://github.com/humanmade/product-dev/issues/1539

## Test plan

- [ ] CI runs green once the dev-tools PR is merged
- [ ] `DOCKER_USERNAME` / `DOCKER_PASSWORD` repo secrets exist
- [ ] Codeception output uploads as artifact on a forced failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)