### PR TITLE
Update plugin install docs to use WP Packages

### DIFF
--- a/other-docs/getting-started/third-party-plugins.md
+++ b/other-docs/getting-started/third-party-plugins.md
@@ -39,9 +39,9 @@ into the correct directory:
 
 Some plugins are not available natively on Packagist, and are available only via
 the [WordPress.org Plugin Repository](https://wordpress.org/plugins/). These can be installed via a third-party Composer repository
-called [WordPress Packagist](https://wpackagist.org/).
+called [WP Packages](https://wp-packages.org/).
 
-To set up and configure WordPress Packagist, first add the custom repository to your project's `composer.json` under
+To set up and configure WP Packages, first add the custom repository to your project's `composer.json` under
 a `repositories` key:
 
 ```json
@@ -49,20 +49,20 @@ a `repositories` key:
     "repositories": [
         {
             "type": "composer",
-            "url": "https://wpackagist.org"
+            "url": "https://repo.wp-packages.org"
         }
     ]
 }
 ```
 
-To install plugins, you can now use `composer require wpackagist-plugin/{plugin-name}`, where `{plugin-name}` is the "slug" of the
+To install plugins, you can now use `composer require wp-plugin/{plugin-name}`, where `{plugin-name}` is the "slug" of the
 plugin from the WordPress.org Plugin Repository to install.
 
 For example, [Akismet](https://wordpress.org/plugins/akismet/) is available at `https://wordpress.org/plugins/akismet/`, so the "
 slug" of the plugin is `akismet`. You can install this with:
 
 ```sh
-composer require wpackagist-plugin/akismet
+composer require wp-plugin/akismet
 ```
 
 ## Managing Plugins Manually

--- a/other-docs/getting-started/third-party-plugins.md
+++ b/other-docs/getting-started/third-party-plugins.md
@@ -41,8 +41,13 @@ Some plugins are not available natively on Packagist, and are available only via
 the [WordPress.org Plugin Repository](https://wordpress.org/plugins/). These can be installed via a third-party Composer repository
 called [WP Packages](https://wp-packages.org/).
 
-To set up and configure WP Packages, first add the custom repository to your project's `composer.json` under
-a `repositories` key:
+To set up and configure WP Packages, run the following command from your project root:
+
+```sh
+composer config repositories.wp-packages composer https://repo.wp-packages.org
+```
+
+Or add the repository manually to your project's `composer.json` under a `repositories` key:
 
 ```json
 {


### PR DESCRIPTION
This PR updates https://docs.altis-dxp.com/getting-started/third-party-plugins/ to use WP Packages instead of WPackagist for installing WordPress.org plugins via Composer.

[WP Packages](https://wp-packages.org) is a faster, independent, fully open-source alternative to WPackagist with the same purpose — mirrors WordPress.org plugins/themes as Composer packages:

- ~17x faster Composer resolves
- Updates every 5 minutes vs. ~1.5 hours
- Comparison: https://wp-packages.org/wp-packages-vs-wpackagist

### Changes

- Repository URL: `https://wpackagist.org` → `https://repo.wp-packages.org`
- Install commands: `wpackagist-plugin/{name}` → `wp-plugin/{name}`
- Prose: "WordPress Packagist" → "WP Packages"

### Side note (separate from this PR)

While reviewing, I noticed [altis-cms](https://github.com/humanmade/altis-cms/blob/master/composer.json) uses `johnpbloch/wordpress`. Worth considering Roots' alternative which offers a few benefits: multiple WordPress build flavors (`full`, `no-content`, beta/RC support), and more frequent maintenance (the [Roots Composer + WordPress resource page covers it](https://roots.io/composer-wordpress-resources/)) 

Just flagging — unrelated to this PR.

Happy to adjust anything.

**Disclosure:** I maintain [WP Packages](https://wp-packages.org) / [Bedrock](https://roots.io/bedrock/).

